### PR TITLE
Add unit tests for plexApi and plexPlayerTimeline

### DIFF
--- a/server/lib/plexApi.spec.ts
+++ b/server/lib/plexApi.spec.ts
@@ -1,0 +1,95 @@
+import axios from 'axios'
+import { parseStringPromise } from 'xml2js'
+import * as plexApi from './plexApi'
+import type { Track, PlayQueue } from './plexPlayerTimeline'
+import { describe, expect, it, vi, type Mock } from 'vitest'
+
+vi.mock('axios')
+vi.mock('xml2js', () => ({
+  parseStringPromise: vi.fn()
+}))
+
+vi.mock('../composables/useLogger', () => ({
+  default: () => ({
+    warn: vi.fn()
+  })
+}))
+
+const mockPlexServer: plexApi.PlexServer = {
+  server: {
+    protocol: 'http',
+    localAddress: '127.0.0.1',
+    port: 32400
+  } as any,
+  token: 'token123'
+}
+
+const mockTrack: Track = {
+  $: {
+    grandparentTitle: 'Artist',
+    parentTitle: 'Album',
+    title: 'Song'
+  },
+  Media: [
+    {
+      Part: [
+        {
+          $: { key: '/library/parts/1/file.mp3' }
+        }
+      ]
+    }
+  ]
+} as any
+
+describe('plexApi', () => {
+  describe('responseHeaders', () => {
+    it('should return headers with correct values', () => {
+      const headers = plexApi.responseHeaders('pid', 'pname', 'application/json')
+      expect(headers.get('Content-Type')).toBe('application/json')
+      expect(headers.get('X-Plex-Client-Identifier')).toBe('pid')
+      expect(headers.get('X-Plex-Device-Name')).toBe('pname')
+    })
+  })
+
+  describe('getPlexApi', () => {
+    it('should build the correct API URL', () => {
+      const url = plexApi.getPlexApi(mockPlexServer, '/foo')
+      expect(url).toBe('http://127.0.0.1:32400/foo')
+    })
+  })
+
+  describe('getPlexApiTrack', () => {
+    it('should build the correct track URL', () => {
+      const url = plexApi.getPlexApiTrack(mockPlexServer, mockTrack)
+      expect(url).toBe('http://127.0.0.1:32400/library/parts/1/file.mp3?X-Plex-Token=token123')
+    })
+  })
+
+  describe('metadata', () => {
+    it('should return formatted metadata string', () => {
+      const meta = plexApi.metadata(mockTrack)
+      expect(meta).toBe('Artist - Song (Album)')
+    })
+  })
+
+  describe('getPlayQueue', () => {
+    it('should fetch and parse playQueue', async () => {
+      ;(axios.get as Mock).mockResolvedValue({ data: '<xml></xml>' })
+      ;(parseStringPromise as Mock).mockResolvedValue({ PlayQueue: 'parsed' })
+      const result = await plexApi.getPlayQueue(mockPlexServer, '/playQueues/123')
+      expect(axios.get).toHaveBeenCalledWith('http://127.0.0.1:32400/playQueues/123', expect.any(Object))
+      expect(parseStringPromise).toHaveBeenCalledWith('<xml></xml>')
+      expect(result).toEqual({ PlayQueue: 'parsed' })
+    })
+
+    it('should throw if no data returned', async () => {
+      ;(axios.get as Mock).mockResolvedValue({ data: '' })
+      await expect(plexApi.getPlayQueue(mockPlexServer, '/playQueues/123')).rejects.toThrow('Failed to fetch playQueue')
+    })
+
+    it('should throw on error', async () => {
+      ;(axios.get as Mock).mockRejectedValue(new Error('fail'))
+      await expect(plexApi.getPlayQueue(mockPlexServer, '/playQueues/123')).rejects.toThrow('Failed to fetch playQueue')
+    })
+  })
+})

--- a/server/lib/plexApi.ts
+++ b/server/lib/plexApi.ts
@@ -29,26 +29,28 @@ export const responseHeaders = (playerId: string, playerName: string, contentTyp
     'Access-Control-Allow-Methods': 'POST, GET, OPTIONS, DELETE, PUT, HEAD',
     'Access-Control-Allow-Origin': '*',
     'Access-Control-Allow-Private-Network': 'true',
-    'Access-Control-Max-Age': '1209600'
-    //'Access-Control-Expose-Headers': 'X-Plex-Client-Identifier'
+    'Access-Control-Max-Age': '1209600'    
   })
-
-// TODO we should never use the public plex address since we need to send the plex token as url query parameter for LMS to stream from it. I can't think of a valid where using the public plex address would be useful in our LMS use case
-export function getPlexApiUrl(protocol: string, address: string, port: string, path: string): string {
-  return `${protocol}://${address}:${port}${path}`
-}
 
 export function getPlexApi(plexServer: PlexServer, path: string): string {
   return `${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}${path}`
 }
 
+/**
+ * Generates the Plex API URL for a specific track.
+ * This URL can be used to stream the track directly from the Plex server until the token expires.
+ * 
+ * @param plexServer Plex server to generate the API URL for
+ * @param meta Track metadata to generate the API URL for
+ * @returns Plex API URL for the given track to stream it
+ */
 export function getPlexApiTrack(plexServer: PlexServer, meta: Track): string {
   return `${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}${meta.Media[0].Part[0].$.key}?X-Plex-Token=${plexServer.token}`
   //TODO return `${protocol}://${address}:${port}${track.file}?X-Plex-Token=${token}&artist=mytitle&title=blubber&cover=https%3A%2F%2Fwww.rockarchive.com%2Fmedia%2F1890%2Fdavid-bowie-db001duffy.jpg%3Fcrop%3D0.19186424300418511%2C0.18786141133986681%2C0.20427102269629802%2C0.20827385436061632%26cropmode%3Dpercentage%26width%3D800%26height%3D800%26rnd%3D132951122240000000%26overlay%3Dwatermark.png%26overlay.size%3D230%2C20%26overlay.position%3D0%2C780`
 }
 
 /**
- * Returns metadata string that LMS seems to be able to parse.
+ * Returns metadata string that LMS seems to be able to parse for file stream.
  * @param track track to generate LMS metadata
  * @returns LMS for LMS
  *
@@ -59,7 +61,8 @@ export function metadata(meta: Track): string {
 }
 
 /**
- *
+ * Returns Plex playQueue for the given container key. 
+ * 
  * @param plexServer
  * @param containerKey e.g. /playQueues/1234
  * @returns parsed PlayQueue object

--- a/server/lib/plexPlayerTimeline.spec.ts
+++ b/server/lib/plexPlayerTimeline.spec.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { PlayerStatus } from '~/server/lib/squeezePlayer'
+import type { RemoteSubscriber } from '../routes/player/timeline/poll.get'
+import type { PlexServer } from './plexApi'
+import type { PlayerPlayQueue, PlayQueue, Track } from './plexPlayerTimeline'
+import { plexOptions } from './squeezePlexHub'
+import { timelineResponse } from './plexPlayerTimeline'
+
+vi.mock('../composables/useLogger', () => ({
+  default: () => ({
+    warn: vi.fn(),
+    debug: vi.fn()
+  })
+}))
+
+const mockSubscriber: RemoteSubscriber = {
+  commandId: '123'
+} as any
+
+const mockPlexServer: PlexServer = {
+  server: {
+    resourceIdentifier: 'server-uuid',
+    protocol: 'https',
+    localAddress: '127.0.0.1',
+    port: 32400
+  }
+} as any
+
+const mockTrack: Track = {
+  $: {
+    playQueueItemID: '582408',
+    ratingKey: '40900',
+    key: '/library/metadata/40900',
+    parentRatingKey: '40888',
+    grandparentRatingKey: '40887',
+    guid: 'local://40900',
+    parentGuid: 'local://40888',
+    grandparentGuid: 'plex://artist/5d07bf25403c64029071b92d',
+    type: 'track',
+    title: 'Save You with My Love',
+    grandparentKey: '/library/metadata/40887',
+    parentKey: '/library/metadata/40888',
+    librarySectionTitle: 'Music',
+    librarySectionID: '1',
+    librarySectionKey: '/library/sections/1',
+    grandparentTitle: 'TheCityIsOurs',
+    parentTitle: 'COMA',
+    summary: '',
+    index: '12',
+    parentIndex: '1',
+    ratingCount: '0',
+    viewCount: '20',
+    lastViewedAt: '1739294768',
+    parentYear: '2021',
+    thumb: '/library/metadata/40888/thumb/1672307105',
+    art: '',
+    parentThumb: '/library/metadata/40888/thumb/1672307105',
+    grandparentThumb: '/library/metadata/40887/thumb/1710899270',
+    grandparentArt: '',
+    duration: '302013',
+    addedAt: '1672307103',
+    updatedAt: '',
+    musicAnalysisVersion: '1'
+  },
+  Media: [],
+  Image: [],
+  Guid: []
+}
+
+const mockPlayQueue: PlayQueue = {
+  MediaContainer: {
+    $: {
+      size: '1',
+      identifier: 'com.plexapp.plugins.library',
+      mediaTagPrefix: '/system/bundle/media/flags/',
+      mediaTagVersion: '168',
+      playQueueID: '7509',
+      playQueueLastAddedItemID: '582408',
+      playQueueSelectedItemID: '582408',
+      playQueueSelectedItemOffset: '0',
+      playQueueSelectedMetadataItemID: '40900',
+      playQueueShuffled: '1',
+      playQueueSourceURI: '',
+      playQueueTotalCount: '1',
+      playQueueVersion: '5'
+    },
+    Track: [mockTrack]
+  }
+}
+
+const mockPlayerQueue: PlayerPlayQueue = {
+  playQueue: mockPlayQueue,
+  plexServer: mockPlexServer,
+  playerId: 'player-1'
+}
+
+describe('timelineContainer', () => {
+  let playerStatus: PlayerStatus
+
+  beforeEach(() => {
+    playerStatus = {
+      playerId: 'player-1',
+      mode: 'play',
+      time: 12.345,
+      duration: 123.456,
+      volume: 80,
+      playlist_cur_index: 0
+    } as any
+  })
+
+  it('generates timeline with metadata when includeMetadata is true', async () => {
+    const result = await timelineResponse(playerStatus, mockSubscriber, mockPlayerQueue, true)
+    expect(result.MediaContainer.$.commandID).toBe(mockSubscriber.commandId)
+    expect(result.MediaContainer.Timeline[0].$.state).toBe('playing')
+    expect(result.MediaContainer.Timeline[0].$.duration).toBe('123456')
+    expect(result.MediaContainer.Timeline[0].$.time).toBe('12345')
+    expect(result.MediaContainer.Timeline[0].$.playQueueItemID).toBe('582408')
+    expect(result.MediaContainer.Timeline[0].$.key).toBe('/library/metadata/40900')
+    expect(result.MediaContainer.Timeline[0].$.playQueueID).toBe('7509')
+    expect(result.MediaContainer.Timeline[0].$.playQueueVersion).toBe('5')
+    expect(result.MediaContainer.Timeline[0].$.containerKey).toBe('/playQueues/7509')
+    expect(result.MediaContainer.Timeline[0].$.type).toBe('music')
+    expect(result.MediaContainer.Timeline[0].$.itemType).toBe('music')
+    expect(result.MediaContainer.Timeline[0].$.volume).toBe('80')
+    expect(result.MediaContainer.Timeline[0].$.mute).toBe('0')
+    expect(result.MediaContainer.Timeline[0].$.shuffle).toBe('1')
+    expect(result.MediaContainer.Timeline[0].$.repeat).toBe('0')
+    expect(result.MediaContainer.Timeline[0].$.controllable).toBe(plexOptions.controllable)
+    expect(result.MediaContainer.Timeline[0].$.machineIdentifier).toBe('server-uuid')
+    expect(result.MediaContainer.Timeline[0].$.protocol).toBe('https')
+    expect(result.MediaContainer.Timeline[0].$.address).toBe('127.0.0.1')
+    expect(result.MediaContainer.Timeline[0].$.port).toBe('32400')
+    expect(result.MediaContainer.Timeline[0].Track).toBeDefined()
+    expect(result.MediaContainer.Timeline[1].$.type).toBe('video')
+    expect(result.MediaContainer.Timeline[2].$.type).toBe('photo')
+  })
+
+  it('generates timeline without metadata when includeMetadata is false', async () => {
+    const result = await timelineResponse(playerStatus, mockSubscriber, mockPlayerQueue, false)
+    expect(result.MediaContainer.Timeline[0].Track).toBeUndefined()
+  })
+
+  it('sets state to paused when playerStatus.mode is pause', async () => {
+    playerStatus.mode = 'pause'
+    const result = await timelineResponse(playerStatus, mockSubscriber, mockPlayerQueue, true)
+    expect(result.MediaContainer.Timeline[0].$.state).toBe('paused')
+  })
+
+  it('sets state to stopped when playerStatus.mode is stop', async () => {
+    playerStatus.mode = 'stop'
+    const result = await timelineResponse(playerStatus, mockSubscriber, mockPlayerQueue, true)
+    expect(result.MediaContainer.Timeline[0].$.state).toBe('stopped')
+  })
+
+  it('sets mute to 1 and volume to 0 when playerStatus.volume is negative', async () => {
+    playerStatus.volume = -1
+    const result = await timelineResponse(playerStatus, mockSubscriber, mockPlayerQueue, true)
+    expect(result.MediaContainer.Timeline[0].$.mute).toBe('1')
+    expect(result.MediaContainer.Timeline[0].$.volume).toBe('0')
+  })
+
+  it('returns undefined keys if no playQueue is provided', async () => {
+    const result = await timelineResponse(playerStatus, mockSubscriber, undefined, true)
+    expect(result.MediaContainer.Timeline[0].$.playQueueID).toBeUndefined()
+    expect(result.MediaContainer.Timeline[0].$.containerKey).toBeUndefined()
+    expect(result.MediaContainer.Timeline[0].Track).toBeUndefined()
+  })
+
+  it('returns undefined for playQueueItemID if playlist_cur_index is out of bounds', async () => {
+    playerStatus.playlist_cur_index = 99
+    const result = await timelineResponse(playerStatus, mockSubscriber, mockPlayerQueue, true)
+    expect(result.MediaContainer.Timeline[0].$.playQueueItemID).toBeUndefined()
+    expect(result.MediaContainer.Timeline[0].Track).toBeUndefined()
+  })
+})

--- a/server/lib/plexPlayerTimeline.spec.ts
+++ b/server/lib/plexPlayerTimeline.spec.ts
@@ -60,7 +60,8 @@ const mockTrack: Track = {
     duration: '302013',
     addedAt: '1672307103',
     updatedAt: '',
-    musicAnalysisVersion: '1'
+    musicAnalysisVersion: '1',
+    parentStudio: ''
   },
   Media: [],
   Image: [],

--- a/server/lib/plexPlayerTimeline.ts
+++ b/server/lib/plexPlayerTimeline.ts
@@ -388,7 +388,7 @@ const timelineContainer = (
             itemType: 'music',
             volume: volume(),
             mute: mute(),
-            shuffle: playerQueue?.playQueue?.MediaContainer.$.playQueueShuffled ? '1' : '0',
+            shuffle: playerQueue?.playQueue?.MediaContainer.$.playQueueShuffled,
             repeat: '0',
             controllable: plexOptions.controllable,
             machineIdentifier: playerQueue?.plexServer?.server.resourceIdentifier, // THIS IS ESSENTIAL TO GET THE TIMELINE TO WORK, needs to reflect the serverId of the server that hosts the playQueue. All the server information must match with what was received in createPlayeQueue request
@@ -455,127 +455,6 @@ const timelineContainer = (
     }
   }
 }
-
-// TODO refactor to use js objects instead of xml
-// https://github.com/Leonidas-from-XIV/node-xml2js?tab=readme-ov-file#so-you-wanna-some-json
-// export function timelineBody(
-//   playerStatus: PlayerStatus,
-//   subscriber: RemoteSubscriber, // TODO REMOVE
-//   plexServer?: PlexServer,
-//   includeMetadata?: boolean, // TODO implement metadata
-//   playQueue?: PlexPlayQueue
-// ) {
-//   //logger.info(`Generating timeline XML for player ${JSON.stringify(playerStatus)} ..`)
-//   //logger.info(`Generating timeline XML for playQueue ${JSON.stringify(playQueue)} ..`)
-//   function findCurrentTrack() {
-//     return playQueue?.MediaContainer.Metadata[playerStatus.playlist_cur_index]
-//   }
-
-//   // TODO fetch from plex api /metadata/$key
-//   // TODO transform playQueue JSON to XML
-//   const metadata = (track?: PlexTrack) => {
-//     if (!track) return undefined
-//     return {
-//       $: {
-//         type: 'music',
-//         itemType: 'music',
-//         title: track.title,
-//         parentTitle: track.album,
-//         grandparentTitle: track.artist,
-//         key: track.key,
-//         ratingKey: track.ratingKey,
-//         guid: track.guid,
-//         playQueueItemID: track.playQueueItemID
-//       }
-//     }
-//   }
-
-//   const timeLineMusic = {
-//     $: {
-//       type: 'music',
-//       itemType: 'music',
-//       state: playerStatus.mode == 'play' ? 'playing' : 'stopped', // TODO map pause,stop and play, buffering and error
-//       playQueueID: playQueue?.MediaContainer.playQueueID,
-//       playQueueVersion: playQueue?.MediaContainer.playQueueVersion,
-//       containerKey: `/playQueues/${playQueue?.MediaContainer.playQueueID}`,
-//       key: findCurrentTrack()?.key,
-//       playQueueItemID: findCurrentTrack()?.playQueueItemID,
-//       //audioStreamID: findCurrentTrack()?.Media[0].Part[0].Stream[0].id,
-//       //guid: findCurrentTrack()?.guid,
-//       ratingKey: findCurrentTrack()?.ratingKey,
-//       time: Math.round(playerStatus.time * 1000), // the current time of the track playing in ms
-//       duration: Math.round((playerStatus.duration || 1) * 1000), // the total duration of the track in ms
-//       seekRange: `0-${Math.round((playerStatus.duration || 1) * 1000)}`,
-//       repeat: '0',
-//       mute: '0',
-//       volume: '50', // TODO
-//       shuffle: playQueue?.MediaContainer.playQueueShuffled ? '1' : '0',
-//       //machineIdentifier: 'SqueezePlexHub', // this MUST match the clientIdentifier used to register SqueezePlexHub with Plex Server??
-//       machineIdentifier: playerStatus.playerId,
-//       port: plexServer?.port,
-//       address: plexServer?.host,
-//       protocol: plexServer?.protocol,
-//       //token: subscriber.plexServer?.token,
-//       controllable: 'volume,repeat,skipPrevious,seekTo,stepBack,stepForward,stop,playPause,shuffle,skipNext'
-//       //controllable: 'playPause,stop,skipPrevious,skipNext'
-//       //controllable: 'subtitleStream,videoStream,audioStream,shuffle,repeat,stop,playPause,stepBack,seekTo,stepForward,skipNext'
-//     }
-//     //Track: includeMetadata ? metadata(findCurrentTrack()) : undefined
-//   }
-
-//   // TODO check how we can match the playerStatus to the playQueue
-//   const mediaContainer = {
-//     MediaContainer: {
-//       $: {
-//         commandID: subscriber.commandId
-//         //location: 'fullScreenMusic',
-//         //location: 'navigation',
-//         //machineIdentifier: playerStatus.playerId
-//       },
-//       Timeline: [playQueue ? timeLineMusic : createEmptyTimeline('music'), createEmptyTimeline('video'), createEmptyTimeline('photo')]
-//     }
-//   }
-
-//   const mediaContainerEmpty = {
-//     MediaContainer: {
-//       $: {
-//         commandID: subscriber.commandId,
-//         machineIdentifier: playerStatus.playerId,
-//         location: 'fullScreenMusic',
-//         size: '3'
-//       },
-//       Timeline: [
-//         {
-//           $: {
-//             type: 'music',
-//             time: '0',
-//             seekRange: '0-0',
-//             controllable: 'playPause,stop,skipPrevious,skipNext'
-//           }
-//         },
-//         {
-//           $: {
-//             type: 'video',
-//             time: '0',
-//             seekRange: '0-0',
-//             controllable: 'playPause,stop,skipPrevious,skipNext'
-//           }
-//         },
-//         {
-//           $: {
-//             type: 'photo',
-//             time: '0',
-//             seekRange: '0-0',
-//             controllable: 'playPause,stop,skipPrevious,skipNext'
-//           }
-//         }
-//       ]
-//     }
-//   }
-//   //const builder = new Builder({ headless: true })
-//   //return builder.buildObject(mediaContainer)
-//   return mediaContainer
-// }
 
 export async function timelineResponse(
   playerStatus: PlayerStatus,

--- a/server/lib/squeezePlayer.spec.ts
+++ b/server/lib/squeezePlayer.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import ExtendedSqueezePlayer, { type PlayerStatus } from './squeezePlayer'
+import type { SqueezeServerStub } from 'lms-squeeze-rpc-x'
+import type { IPlayerInfo } from 'lms-squeeze-rpc-x/dist/modelTypes'
+
+const mockPlayerInfo: IPlayerInfo = {
+  playerid: 'abc123',
+  name: 'Test Player',
+  model: 'A-Model',
+  modelname: 'Test Model Name',
+  firmware: '1.0',
+  ip: '1.0.0.127'
+}
+
+function createStub() {
+  return {
+    requestAsync: vi.fn()
+  } as unknown as SqueezeServerStub
+}
+
+describe('ExtendedSqueezePlayer', () => {
+  let stub: SqueezeServerStub
+  let player: ExtendedSqueezePlayer
+
+  beforeEach(() => {
+    stub = createStub()
+    player = new ExtendedSqueezePlayer(stub, mockPlayerInfo)
+    vi.clearAllMocks()
+  })
+
+  it('calls addToPlaylist with correct args', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('ok')
+    const result = await player.addToPlaylist('track.flac', 'Track Title')
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['playlist', 'add', 'track.flac', 'Track Title']])
+    expect(result).toBe('ok')
+  })
+
+  it('calls clearPlaylist', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('cleared')
+    const result = await player.clearPlaylist()
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['playlist', 'clear']])
+    expect(result).toBe('cleared')
+  })
+
+  it('calls selectTrackInPlaylist', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('selected')
+    const result = await player.selectTrackInPlaylist('2')
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['playlist', 'index', '2']])
+    expect(result).toBe('selected')
+  })
+
+  it('calls play', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('playing')
+    const result = await player.play()
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['play', '5']])
+    expect(result).toBe('playing')
+  })
+
+  it('calls stop', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('stopped')
+    const result = await player.stop()
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['stop']])
+    expect(result).toBe('stopped')
+  })
+
+  it('calls pause', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('paused')
+    const result = await player.pause()
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['pause']])
+    expect(result).toBe('paused')
+  })
+
+  it('calls skipNext', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('next')
+    const result = await player.skipNext()
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['playlist', 'index', '+1']])
+    expect(result).toBe('next')
+  })
+
+  it('calls skipPrevious', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('prev')
+    const result = await player.skipPrevious()
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['playlist', 'index', '-1']])
+    expect(result).toBe('prev')
+  })
+
+  it('calls seekTo', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue('seeked')
+    const result = await player.seekTo(42)
+    expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['time', '42']])
+    expect(result).toBe('seeked')
+  })
+
+  it('returns status with correct mapping', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue({
+      mode: 'play',
+      time: '12.5',
+      playlist_cur_index: '1',
+      playlist_tracks: '10',
+      duration: '180.0',
+      'mixer volume': '55'
+    })
+    const status = await player.status()
+    expect(status).toEqual({
+      playerId: 'abc123',
+      mode: 'play',
+      time: 12.5,
+      playlist_cur_index: 1,
+      playlist_tracks: 10,
+      duration: 180.0,
+      volume: 55
+    })
+  })
+
+  it('returns undefined if status response is falsy', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue(undefined)
+    const status = await player.status()
+    expect(status).toBeUndefined()
+  })
+
+  it('handles missing/invalid status fields gracefully', async () => {
+    ;(stub.requestAsync as Mock).mockResolvedValue({
+      mode: undefined,
+      time: undefined,
+      playlist_cur_index: undefined,
+      playlist_tracks: undefined,
+      duration: undefined,
+      'mixer volume': undefined
+    })
+    const status = await player.status()
+    expect(status).toEqual({
+      playerId: 'abc123',
+      mode: undefined,
+      time: 0,
+      playlist_cur_index: 0,
+      playlist_tracks: 0,
+      duration: 0,
+      volume: 0
+    })
+  })
+})


### PR DESCRIPTION
This pull request introduces extensive changes to improve test coverage, refactor code, and enhance functionality for the Plex and SqueezePlayer integrations. Key updates include new test files for `plexApi`, `plexPlayerTimeline`, and `squeezePlayer`, as well as the addition of helper methods and refactoring to simplify code and remove unused functionality.
