### PR TITLE
feat: support refresh playQueue functionality

### DIFF
--- a/app/components/DiscoveredDevices.vue
+++ b/app/components/DiscoveredDevices.vue
@@ -31,7 +31,7 @@
                 :src="`http://${player.serverInfo.ip}:${player.serverInfo.jsonPort}/html/images/Players/${player.playerInfo.model}_250x250.png`"
                 :alt="`Player Model: ${player.playerInfo.model}`"
                 class="player-image"
-              />
+              >
               <div>
                 <p>🆔 {{ player.playerInfo.playerid }}</p>
                 <p>📶 {{ player.playerInfo.ip }}</p>

--- a/app/components/DiscoveredDevices.vue
+++ b/app/components/DiscoveredDevices.vue
@@ -31,7 +31,7 @@
                 :src="`http://${player.serverInfo.ip}:${player.serverInfo.jsonPort}/html/images/Players/${player.playerInfo.model}_250x250.png`"
                 :alt="`Player Model: ${player.playerInfo.model}`"
                 class="player-image"
-              >
+              />
               <div>
                 <p>🆔 {{ player.playerInfo.playerid }}</p>
                 <p>📶 {{ player.playerInfo.ip }}</p>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <header>
-      <img src="/logo_512.png" alt="Squeeze Plex Hub" />
+      <img src="/logo_512.png" alt="Squeeze Plex Hub" >
     </header>
     <main>
       <DiscoveredDevices />

--- a/server/lib/squeezePlayer.ts
+++ b/server/lib/squeezePlayer.ts
@@ -33,12 +33,12 @@ class ExtendedSqueezePlayer extends SqueezePlayer {
     return this.stub.requestAsync([this.id, ['playlist', 'clear']])
   }
 
-  async deleteByIndexPlaylist(index: number) {
+  async deleteTrackFromPlaylist(index: number) {
     return this.stub.requestAsync([this.id, ['playlist', 'delete', index.toString()]])
   }
 
-  async selectTrackInPlaylist(index: string) {
-    return this.stub.requestAsync([this.id, ['playlist', 'index', index]])
+  async selectTrackInPlaylist(index: number) {
+    return this.stub.requestAsync([this.id, ['playlist', 'index', index.toString()]])
   }
 
   async play() {

--- a/server/lib/squeezePlayer.ts
+++ b/server/lib/squeezePlayer.ts
@@ -33,6 +33,10 @@ class ExtendedSqueezePlayer extends SqueezePlayer {
     return this.stub.requestAsync([this.id, ['playlist', 'clear']])
   }
 
+  async deleteByIndexPlaylist(index: number) {
+    return this.stub.requestAsync([this.id, ['playlist', 'delete', index.toString()]])
+  }
+
   async selectTrackInPlaylist(index: string) {
     return this.stub.requestAsync([this.id, ['playlist', 'index', index]])
   }

--- a/server/routes/player/playback/createPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/createPlayQueue.get.spec.ts
@@ -165,7 +165,7 @@ describe('playback.createPlayQueue route', () => {
     // Assert that addToPlaylist is called for each track in the playQueue
     expect(mockPlayer.addToPlaylist).toHaveBeenCalledTimes(2)
     // Assert that selectTrackInPlaylist is called with the correct offset
-    expect(mockPlayer.selectTrackInPlaylist).toHaveBeenCalledWith('4')
+    expect(mockPlayer.selectTrackInPlaylist).toHaveBeenCalledWith(4)
     // Assert that play is called after adding tracks and selecting track
     expect(mockPlayer.play).toHaveBeenCalledTimes(1)
 

--- a/server/routes/player/playback/createPlayQueue.get.ts
+++ b/server/routes/player/playback/createPlayQueue.get.ts
@@ -125,7 +125,7 @@ export default eventHandler(async (event) => {
       const trackUrl = getPlexApiTrack(plexServer, meta)
       await player.addToPlaylist(trackUrl, metadata(meta))
     }
-    await player.selectTrackInPlaylist(playQueue.MediaContainer.$.playQueueSelectedItemOffset)
+    await player.selectTrackInPlaylist(Number(playQueue.MediaContainer.$.playQueueSelectedItemOffset))
     await player.play()
     logger.info(
       `Playing playlist index '${playQueue.MediaContainer.$.playQueueSelectedItemOffset}' on player '${playerInfo.name} / ${playerInfo.playerid}'`

--- a/server/routes/player/playback/playMedia.get.spec.ts
+++ b/server/routes/player/playback/playMedia.get.spec.ts
@@ -130,7 +130,7 @@ describe('playback.playMedia route', () => {
 
     expect(mockPlayer.clearPlaylist).toHaveBeenCalledTimes(1)
     expect(mockPlayer.addToPlaylist).toHaveBeenCalledWith('http://10.10.1.1/track1', 'metadata-string')
-    expect(mockPlayer.selectTrackInPlaylist).toHaveBeenCalledWith('4')
+    expect(mockPlayer.selectTrackInPlaylist).toHaveBeenCalledWith(4)
     expect(setItemMock).toHaveBeenCalledWith('playerQueue/123', expect.anything())
 
     expect(h3.setResponseHeaders).toHaveBeenCalledWith(event, expect.anything())

--- a/server/routes/player/playback/playMedia.get.ts
+++ b/server/routes/player/playback/playMedia.get.ts
@@ -76,7 +76,7 @@ export default eventHandler(async (event) => {
     }
 
     logger.info(`Playing playlist item '${playQueue.MediaContainer.$.playQueueSelectedItemOffset}' on player '${playerInfo.name}'`)
-    await player.selectTrackInPlaylist(playQueue.MediaContainer.$.playQueueSelectedItemOffset)
+    await player.selectTrackInPlaylist(Number(playQueue.MediaContainer.$.playQueueSelectedItemOffset))
     await storage.setItem(`playerQueue/${playerInfo.playerid}`, playerQueue)
 
     setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import * as h3 from 'h3'
+import handler from './refreshPlayQueue.get'
+
+vi.mock('../../../composables/useLogger', () => {
+  const wrap = (level: string) =>
+    vi.fn((...args: any[]) => {
+      console.log(`[logger:${level}]`, ...args)
+    })
+
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      info: wrap('info'),
+      warn: wrap('warn'),
+      error: wrap('error'),
+      debug: wrap('debug')
+    }))
+  }
+})
+
+const playerInfoMock = { playerid: '123', name: 'Living Room' }
+vi.mock('../../../composables/usePlayerInfo', () => ({
+  default: vi.fn(async () => ({ playerInfo: playerInfoMock }))
+}))
+
+const playerStatusMock = { playlist_cur_index: 1, playlist_tracks: 3 }
+const mockPlayer = {
+  status: vi.fn().mockResolvedValue(playerStatusMock),
+  deleteTrackFromPlaylist: vi.fn().mockResolvedValue(undefined),
+  addToPlaylist: vi.fn().mockResolvedValue(undefined)
+}
+vi.mock('../../../composables/useSqueezePlayer', () => ({
+  default: vi.fn().mockImplementation(() => ({ player: mockPlayer }))
+}))
+
+const setItemMock = vi.fn()
+const getItemMock = vi.fn()
+function useStorage() {
+  return {
+    setItem: setItemMock,
+    getItem: getItemMock
+  }
+}
+vi.stubGlobal('useStorage', useStorage)
+
+vi.mock('../../../lib/plexApi', () => ({
+  responseHeaders: vi.fn().mockImplementation((playerid: string, name: string) => {
+    const h = new Headers()
+    h.set('X-Plex-Player-Id', playerid)
+    h.set('X-Plex-Player-Name', name)
+    return h
+  }),
+  getPlayQueue: vi.fn().mockResolvedValue({
+    MediaContainer: {
+      $: { playQueueSelectedItemOffset: '0' },
+      Track: [
+        { $: { title: 'Track 1' }, Media: [{ Part: [{ $: { key: '1' } }] }] },
+        { $: { title: 'Track 2' }, Media: [{ Part: [{ $: { key: '2' } }] }] }
+      ]
+    }
+  }),
+  getPlexApiTrack: vi.fn().mockReturnValue('http://10.10.1.1/track1'),
+  metadata: vi.fn().mockReturnValue('metadata-string')
+}))
+
+const event: any = {
+  node: { req: { headers: {} } },
+  respondWith: vi.fn()
+}
+
+vi.mock('h3', async (orig) => {
+  const actual = await (orig() as any)
+  const eventHandler = (fn: any) => fn
+  return {
+    ...actual,
+    getQuery: vi.fn().mockImplementation((_event) => ({ playQueueID: 'pqid' })),
+    getRequestHeader: vi.fn(),
+    sendNoContent: vi.fn(),
+    setResponseHeaders: vi.fn(),
+    eventHandler
+  }
+})
+
+const mockHeaders: Record<string, string> = {
+  'X-Plex-Target-Client-Identifier': 'player-1',
+  'X-Plex-Client-Identifier': 'client-1',
+  'X-Plex-Device-Name': 'device-1'
+}
+
+describe('playback.refreshPlayQueue route', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getItemMock.mockReset()
+    setItemMock.mockReset()
+    mockPlayer.status.mockResolvedValue(playerStatusMock)
+    mockPlayer.deleteTrackFromPlaylist.mockResolvedValue(undefined)
+    mockPlayer.addToPlaylist.mockResolvedValue(undefined)
+  })
+
+  it('returns 400 when required headers or playQueueID are missing', async () => {
+    ;(h3.getRequestHeader as Mock).mockImplementation((_e, _name: string) => undefined)
+    await handler(event)
+    expect(event.respondWith).toHaveBeenCalledTimes(1)
+    const resp: Response = event.respondWith.mock.calls[0][0]
+    expect(resp.status).toBe(400)
+    expect(h3.setResponseHeaders).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 if playerQueue is not found for player', async () => {
+    ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
+      return mockHeaders[name]
+    })
+    getItemMock.mockResolvedValue(undefined)
+    await handler(event)
+    expect(getItemMock).toHaveBeenCalled()
+    expect(mockPlayer.deleteTrackFromPlaylist).not.toHaveBeenCalled()
+    expect(mockPlayer.addToPlaylist).not.toHaveBeenCalled()
+    expect(event.respondWith).toHaveBeenCalledTimes(1)
+    const resp: Response = event.respondWith.mock.calls[0][0]
+    expect(resp.status).toBe(404)
+    expect(h3.setResponseHeaders).not.toHaveBeenCalled()
+  })
+
+  it.only('refreshes play queue and updates playlist', async () => {
+    ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
+      return mockHeaders[name]
+    })
+    getItemMock.mockResolvedValue({
+      playerId: playerInfoMock.playerid,
+      playQueue: {},
+      plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
+    })
+    await handler(event)
+    expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalled()
+    // skip the first track which is currently playing (playQueueSelectedItemOffset)
+    expect(mockPlayer.addToPlaylist).toHaveBeenCalledOnce()
+    expect(mockPlayer.addToPlaylist).toHaveBeenCalledWith('http://10.10.1.1/track1', 'metadata-string')
+    expect(setItemMock).toHaveBeenCalledWith('playerQueue/123', expect.anything())
+    expect(h3.setResponseHeaders).toHaveBeenCalledWith(event, expect.anything())
+    expect(h3.sendNoContent).toHaveBeenCalledWith(event, 200)
+    expect(event.respondWith).not.toHaveBeenCalledWith(expect.any(Response))
+  })
+
+  it('returns 404 when player status fails', async () => {
+    ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
+      return mockHeaders[name]
+    })
+    getItemMock.mockResolvedValue({
+      playerId: playerInfoMock.playerid,
+      playQueue: {},
+      plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
+    })
+    mockPlayer.status.mockResolvedValue(undefined)
+    await handler(event)
+    expect(event.respondWith).toHaveBeenCalledTimes(1)
+    const resp: Response = event.respondWith.mock.calls[0][0]
+    expect(resp.status).toBe(404)
+    expect(h3.sendNoContent).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when an error is thrown', async () => {
+    ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
+      return mockHeaders[name]
+    })
+    getItemMock.mockResolvedValue({
+      playerId: playerInfoMock.playerid,
+      playQueue: {},
+      plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
+    })
+    mockPlayer.addToPlaylist.mockRejectedValueOnce(new Error('fail'))
+    await handler(event)
+    expect(event.respondWith).toHaveBeenCalledTimes(1)
+    const resp: Response = event.respondWith.mock.calls[0][0]
+    expect(resp.status).toBe(404)
+    expect(h3.sendNoContent).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -121,7 +121,7 @@ describe('playback.refreshPlayQueue route', () => {
     expect(h3.setResponseHeaders).not.toHaveBeenCalled()
   })
 
-  it.only('refreshes play queue and updates playlist', async () => {
+  it('refreshes play queue and updates playlist', async () => {
     ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
       return mockHeaders[name]
     })

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -1,6 +1,6 @@
 import type { PlayerPlayQueue } from '../../../lib/plexPlayerTimeline'
 import useLogger from '../../../composables/useLogger'
-import { getRequestHeader, getQuery } from 'h3'
+import { getRequestHeader, getQuery, eventHandler, setResponseHeaders, sendNoContent } from 'h3'
 import usePlayerInfo from '../../../composables/usePlayerInfo'
 import useSqueezePlayer from '../../../composables/useSqueezePlayer'
 import { getPlayQueue, getPlexApiTrack, metadata, responseHeaders } from '../../../lib/plexApi'
@@ -37,8 +37,7 @@ export default eventHandler(async (event) => {
     logger.info(`Refreshing playQueue '${playQueueID}' for player '${playerInfo.name}' ..`)
     const playerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? undefined
     if (!playerQueue) {
-      logger.warn(`No playerQueue available for player ${playerInfo.name} (${playerInfo.playerid}), skipping playQueue refresh ..`)
-      return
+      throw new Error(`No playerQueue available for player ${playerInfo.name} (${playerInfo.playerid}), skipping playQueue refresh ..`)
     }
 
     const refreshedPlayQueue = await getPlayQueue(playerQueue.plexServer, `/playQueues/${playQueueID}`)
@@ -76,7 +75,7 @@ export default eventHandler(async (event) => {
   } catch (error) {
     logger.warn(`Error when refreshing play queue for player '${targetClientIdentifier}'`, error)
     return event.respondWith(
-      new Response(`Player '${targetClientIdentifier}' not available for refreshing play queue, try again later`, { status: 404 })
+      new Response(`Player '${targetClientIdentifier}' play queue not available for refreshing, try again later`, { status: 404 })
     )
   }
 })

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -1,25 +1,26 @@
+import type { PlayerPlayQueue } from '../../../lib/plexPlayerTimeline'
 import useLogger from '../../../composables/useLogger'
 import { getRequestHeader, getQuery } from 'h3'
+import usePlayerInfo from '../../../composables/usePlayerInfo'
+import useSqueezePlayer from '../../../composables/useSqueezePlayer'
+import { getPlayQueue, getPlexApiTrack, metadata, responseHeaders } from '../../../lib/plexApi'
 
-// catchAll route triggered: GET /player/playback/refreshPlayQueue?playQueueID=7868&commandID=4400&type=music
 const logger = useLogger('playback.refreshPlayQueue')
 
 /**
  * This will create a play queue on plex server and play it on the target player.
  */
 export default eventHandler(async (event) => {
+  const storage = useStorage('DISCOVERY')
   const query = getQuery(event)
   const targetClientIdentifier = getRequestHeader(event, 'X-Plex-Target-Client-Identifier')
   const clientIdentifier = getRequestHeader(event, 'X-Plex-Client-Identifier')
   const deviceName = getRequestHeader(event, 'X-Plex-Device-Name')
+  const playQueueID = query.playQueueID as string
 
-  logger.info(`Refresh play queue for player '${targetClientIdentifier}' ..`)
-  logger.info(`Query parameters: ${JSON.stringify(query)}`)
-  logger.info(`Headers: ${JSON.stringify(event.node.req.headers)}`)
-
-  if (!targetClientIdentifier || !clientIdentifier || !deviceName) {
+  if (!targetClientIdentifier || !clientIdentifier || !deviceName || !playQueueID) {
     logger.warn(
-      `Missing required parameters ('X-Plex-Target-Client-Identifier', 'X-Plex-Client-Identifier', 'X-Plex-Device-Name' headers), got:`,
+      `Missing required parameters ('X-Plex-Target-Client-Identifier', 'X-Plex-Client-Identifier', 'X-Plex-Device-Name' headers) and playQueueID query parameter, got:`,
       event.node.req.headers
     )
     return event.respondWith(
@@ -31,8 +32,44 @@ export default eventHandler(async (event) => {
   }
 
   try {
-    // TODO figure what to do here, how to refresh the playQueue and when is this triggered?
-    // This route is triggered by plex app when a track has been added or removed from the playQueue
+    const { playerInfo } = await usePlayerInfo(targetClientIdentifier)
+    const { player } = await useSqueezePlayer(targetClientIdentifier)
+    logger.info(`Refreshing playQueue '${playQueueID}' for player '${playerInfo.name}' ..`)
+    const playerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? undefined
+    if (!playerQueue) {
+      logger.warn(`No playerQueue available for player ${playerInfo.name} (${playerInfo.playerid}), skipping playQueue refresh ..`)
+      return
+    }
+
+    const refreshedPlayQueue = await getPlayQueue(playerQueue.plexServer, `/playQueues/${playQueueID}`)
+    const refreshedPlayerQueue: PlayerPlayQueue = {
+      playerId: playerInfo.playerid,
+      playQueue: refreshedPlayQueue,
+      plexServer: playerQueue.plexServer
+    }
+ 
+    const playerStatus = await player.status()
+    if (!playerStatus) {
+      throw new Error(`Could not get status from player '${playerInfo.name}', cannot refresh play queue`)
+    }
+    const currentPlaylistIndex = playerStatus?.playlist_cur_index
+    const playlistTrackCount = playerStatus?.playlist_tracks
+    
+    logger.info(`Cleaning up existing playQueue in player '${playerInfo.name}' from index ${currentPlaylistIndex + 1} to ${playlistTrackCount} to prepare for playQueue refresh ..`)
+    for (let trackIndex = playlistTrackCount - 1; trackIndex > currentPlaylistIndex; trackIndex--) {
+      await player.deleteByIndexPlaylist(trackIndex)
+    }
+
+    const selectedOffset = Number(refreshedPlayQueue.MediaContainer.$.playQueueSelectedItemOffset)
+    const tracks = refreshedPlayQueue.MediaContainer.Track.slice(selectedOffset + 1)
+    for (const track of tracks) {
+      logger.info(`Adding track '${track.$.title}' to refreshed playQueue for player '${playerInfo.name}' ..`)
+      const trackUrl = getPlexApiTrack(playerQueue.plexServer, track)
+      await player.addToPlaylist(trackUrl, metadata(track))
+    }
+    await storage.setItem(`playerQueue/${playerInfo.playerid}`, refreshedPlayerQueue)
+
+    setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))
     return sendNoContent(event, 200)
   } catch (error) {
     logger.warn(`Error when refreshing play queue for player '${targetClientIdentifier}'`, error)

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -47,17 +47,19 @@ export default eventHandler(async (event) => {
       playQueue: refreshedPlayQueue,
       plexServer: playerQueue.plexServer
     }
- 
+
     const playerStatus = await player.status()
     if (!playerStatus) {
       throw new Error(`Could not get status from player '${playerInfo.name}', cannot refresh play queue`)
     }
     const currentPlaylistIndex = playerStatus?.playlist_cur_index
     const playlistTrackCount = playerStatus?.playlist_tracks
-    
-    logger.info(`Cleaning up existing playQueue in player '${playerInfo.name}' from index ${currentPlaylistIndex + 1} to ${playlistTrackCount} to prepare for playQueue refresh ..`)
+
+    logger.info(
+      `Cleaning up existing playQueue in player '${playerInfo.name}' from index ${currentPlaylistIndex + 1} to ${playlistTrackCount} to prepare for playQueue refresh ..`
+    )
     for (let trackIndex = playlistTrackCount - 1; trackIndex > currentPlaylistIndex; trackIndex--) {
-      await player.deleteByIndexPlaylist(trackIndex)
+      await player.deleteTrackFromPlaylist(trackIndex)
     }
 
     const selectedOffset = Number(refreshedPlayQueue.MediaContainer.$.playQueueSelectedItemOffset)

--- a/server/routes/player/playback/skipTo.get.spec.ts
+++ b/server/routes/player/playback/skipTo.get.spec.ts
@@ -16,10 +16,12 @@ vi.mock('../../../composables/usePlayerInfo', () => ({
 }))
 
 const selectTrackInPlaylist = vi.fn()
-vi.mock('../../../lib/squeezePlayer', () => {
+vi.mock('../../../composables/useSqueezePlayer', () => {
   return {
     default: vi.fn().mockImplementation(() => ({
-      selectTrackInPlaylist
+      player: {
+        selectTrackInPlaylist
+      }
     }))
   }
 })

--- a/server/routes/player/playback/skipTo.get.spec.ts
+++ b/server/routes/player/playback/skipTo.get.spec.ts
@@ -192,7 +192,7 @@ describe('GET /server/routes/player/playback/skipTo.get', () => {
 
     await handler(event)
 
-    expect(selectTrackInPlaylist).toHaveBeenCalledWith('1')
+    expect(selectTrackInPlaylist).toHaveBeenCalledWith(1)
     expect(h3.setResponseHeaders as Mock).toHaveBeenCalledTimes(1)
     expect(h3.sendNoContent as Mock).toHaveBeenCalledWith(event, 200)
     expect(event.respondWith).not.toHaveBeenCalled()

--- a/server/routes/player/playback/skipTo.get.ts
+++ b/server/routes/player/playback/skipTo.get.ts
@@ -1,9 +1,9 @@
 import useLogger from '../../../composables/useLogger'
 import usePlayerInfo from '../../../composables/usePlayerInfo'
-import ExtendedSqueezePlayer from '../../../lib/squeezePlayer'
 import { responseHeaders } from '../../../lib/plexApi'
 import type { PlayerPlayQueue } from '../../../lib/plexPlayerTimeline'
 import { eventHandler, getRequestHeader, setResponseHeaders, getQuery, sendNoContent } from 'h3'
+import useSqueezePlayer from '../../../composables/useSqueezePlayer'
 
 const logger = useLogger('playback.skipTo')
 
@@ -35,8 +35,8 @@ export default eventHandler(async (event) => {
   }
 
   try {
-    const { playerInfo, serverStub } = await usePlayerInfo(targetClientIdentifier)
-    const player = new ExtendedSqueezePlayer(serverStub, playerInfo)
+    const { playerInfo } = await usePlayerInfo(targetClientIdentifier)
+    const { player } = await useSqueezePlayer(targetClientIdentifier)
 
     const playerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? undefined
     if (!playerQueue) {

--- a/server/routes/player/playback/skipTo.get.ts
+++ b/server/routes/player/playback/skipTo.get.ts
@@ -55,7 +55,7 @@ export default eventHandler(async (event) => {
       throw new Error(`Could not find track with playQueueItemID ${queryParameters.playQueueItemID} in playerQueue, cannot skipTo`)
     }
 
-    await player.selectTrackInPlaylist(trackIndex.toString()) // LMS wants a 0-based index here
+    await player.selectTrackInPlaylist(trackIndex) // LMS wants a 0-based index here
     logger.info(`Player '${targetClientIdentifier}' skipped to playlist item ${trackIndex}`)
     setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))
     return sendNoContent(event, 200)


### PR DESCRIPTION
This allows to keep the LMS playlist on sync with Plexamp playQueue, when the user modifies the play queue
There is still the issue that smart queues (track radio, "mixes for you") are not being automatically refreshed after the initial 21 tracks.

- [x] refresh playqueue endpoint implemented
- [x] tests