### PR TITLE
#56 automated play queue refresh

### DIFF
--- a/app/components/DiscoveredDevices.vue
+++ b/app/components/DiscoveredDevices.vue
@@ -27,11 +27,12 @@
               <p>
                 <strong>{{ player.playerInfo.name }}</strong>
               </p>
-              <img
+                <img
                 :src="`http://${player.serverInfo.ip}:${player.serverInfo.jsonPort}/html/images/Players/${player.playerInfo.model}_250x250.png`"
                 :alt="`Player Model: ${player.playerInfo.model}`"
                 class="player-image"
-              >
+                @error="event => event.target.src = '/logo_512.png'"
+                >
               <div>
                 <p>🆔 {{ player.playerInfo.playerid }}</p>
                 <p>📶 {{ player.playerInfo.ip }}</p>

--- a/app/components/DiscoveredDevices.vue
+++ b/app/components/DiscoveredDevices.vue
@@ -31,7 +31,7 @@
                 :src="`http://${player.serverInfo.ip}:${player.serverInfo.jsonPort}/html/images/Players/${player.playerInfo.model}_250x250.png`"
                 :alt="`Player Model: ${player.playerInfo.model}`"
                 class="player-image"
-                @error="event => event.target.src = '/logo_512.png'"
+                @error="onImageError"
                 >
               <div>
                 <p>🆔 {{ player.playerInfo.playerid }}</p>
@@ -115,11 +115,18 @@ export default defineComponent({
     })
     onUnmounted(stopPolling)
 
+    // Handle image loading error
+    const onImageError = (event: Event) => {
+      const target = event.target as HTMLImageElement
+      target.src = '/logo_512.png'
+    }
+
     return {
       players,
       groupedPlayers,
       loading,
-      error
+      error,
+      onImageError
     }
   }
 })

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue'
-import DiscoveredDevices from '@/components/DiscoveredDevices.vue'
+import DiscoveredDevices from '../components/DiscoveredDevices.vue'
 
 export default defineComponent({
   components: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -55,7 +55,7 @@ export default {
   modules: ['@nuxt/ui'],
   nitro: {
     scheduledTasks: {
-      '* * * * *': ['gdmDiscovery', 'squeezePlayersScanner'], // run every minute
+      '* * * * *': ['gdmDiscovery', 'squeezePlayersScanner', 'playQueueRefresher'], // run every minute
     },
     experimental: {
       tasks: true

--- a/server/lib/squeezePlayer.spec.ts
+++ b/server/lib/squeezePlayer.spec.ts
@@ -44,7 +44,7 @@ describe('ExtendedSqueezePlayer', () => {
 
   it('calls selectTrackInPlaylist', async () => {
     ;(stub.requestAsync as Mock).mockResolvedValue('selected')
-    const result = await player.selectTrackInPlaylist('2')
+    const result = await player.selectTrackInPlaylist(2)
     expect(stub.requestAsync).toHaveBeenCalledWith(['abc123', ['playlist', 'index', '2']])
     expect(result).toBe('selected')
   })

--- a/server/plugins/timelinePublisher.spec.ts
+++ b/server/plugins/timelinePublisher.spec.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import axios from 'axios'
-import type { ServerInfo } from 'lms-discovery'
 import type { PlayerPlayQueue, TimelineContainer } from '../lib/plexPlayerTimeline'
 import { runPublishTimeline } from './timelinePublisher'
 

--- a/server/plugins/timelinePublisher.spec.ts
+++ b/server/plugins/timelinePublisher.spec.ts
@@ -135,13 +135,6 @@ describe('timelinePublisher', () => {
         subscribedAt: new Date(0).toISOString() // stale subscriber
       })
       .mockResolvedValueOnce({
-        cliPort: '9090',
-        ip: '99.99.99.99',
-        jsonPort: '9000',
-        name: 'Test Server',
-        ver: '1.0'
-      } as ServerInfo)
-      .mockResolvedValueOnce({
         plexServer: {
           server: {
             localAddress: '127.0.0.99',
@@ -159,7 +152,6 @@ describe('timelinePublisher', () => {
     expect(mockGetItem).toHaveBeenCalledWith('players:server1')
     expect(mockGetItem).toHaveBeenCalledWith('players:server2')
     expect(mockGetItem).toHaveBeenCalledWith('subscriber1')
-    expect(mockGetItem).toHaveBeenCalledWith('servers/server1')
     expect(mockGetItem).toHaveBeenCalledWith('playerQueue/abc123')
 
     expect(mockRemoveItem).toHaveBeenCalledWith('subscriber2') // Old subscriber removed

--- a/server/plugins/timelinePublisher.ts
+++ b/server/plugins/timelinePublisher.ts
@@ -90,7 +90,7 @@ export async function runPublishTimeline() {
           const timelineString = builder.buildObject(timeline)
           await Promise.all(
             timeline.MediaContainer.Timeline.map(async (timelineItem) => {
-              logger.info(`Sending timeline '${timelineItem.$.itemType}' to subscriber '${subscriber.deviceName}' ..`)
+              logger.debug(`Sending timeline '${timelineItem.$.itemType}' to subscriber '${subscriber.deviceName}' ..`)
 
               if (
                 !timelineItem.$.state ||

--- a/server/plugins/timelinePublisher.ts
+++ b/server/plugins/timelinePublisher.ts
@@ -1,7 +1,6 @@
 import useLogger from '../composables/useLogger'
 import useSqueezePlayer from '../composables/useSqueezePlayer'
 import type { IPlayerInfo } from 'lms-squeeze-rpc-x/dist/modelTypes'
-import type { ServerInfo } from 'lms-discovery'
 import type { RemoteSubscriber } from '../routes/player/timeline/poll.get'
 import axios from 'axios'
 import { type PlayerPlayQueue, timelineResponse } from '../lib/plexPlayerTimeline'
@@ -20,7 +19,7 @@ export default defineNitroPlugin(() => {
  * This is required for all other clients that subscribe to the timeline via /timeline/subscribe or /timeline/poll with wait=1.
  * The timeline is published every second to all subscribers of the players.
  *
- * This is probably LEGACY functionality for Plex web player and other clients that subscribe to the timeline.
+ * This is probably LEGACY functionality for Plex web player and other clients that subscribe to the timeline instead of pulling directly from the timeline endpoint.
  *
  */
 export async function runPublishTimeline() {
@@ -49,7 +48,7 @@ export async function runPublishTimeline() {
     }
 
     await Promise.all(
-      allPlayers.map(async ([serverId, playerInfo]) => {
+      allPlayers.map(async ([_serverId, playerInfo]) => {
         const subscriberKeys = await storage.getKeys(`subscribers/${playerInfo.playerid}`)
         if (!subscriberKeys || subscriberKeys.length === 0) {
           logger.debug(`No subscribers found for player ${playerInfo.playerid}, skipping`)
@@ -73,12 +72,7 @@ export async function runPublishTimeline() {
 
         // resolve player status and send timeline to all subscribers
         logger.debug(`Publishing timeline to ${playerSubscribers.length} subscribers for player ${playerInfo.playerid} ..`)
-        const serverInfo = await storage.getItem<ServerInfo>(`servers/${serverId}`)
-        if (!serverInfo || !serverInfo.ip) {
-          throw new Error(`SqueezeServerStub not found in storage for player '${playerInfo.playerid}'`)
-        }
         const { player } = await useSqueezePlayer(playerInfo.playerid)
-
         const playerStatus = await player.status()
         if (!playerStatus) {
           throw new Error(`Player ${playerInfo.playerid} status available yet`)
@@ -96,7 +90,7 @@ export async function runPublishTimeline() {
           const timelineString = builder.buildObject(timeline)
           await Promise.all(
             timeline.MediaContainer.Timeline.map(async (timelineItem) => {
-              logger.debug(`Sending timeline '${timelineItem.$.itemType}' to subscriber '${subscriber.deviceName}' ..`)
+              logger.info(`Sending timeline '${timelineItem.$.itemType}' to subscriber '${subscriber.deviceName}' ..`)
 
               if (
                 !timelineItem.$.state ||

--- a/server/routes/player/playback/skipNext.get.spec.ts
+++ b/server/routes/player/playback/skipNext.get.spec.ts
@@ -61,6 +61,9 @@ vi.mock('h3', async (orig) => {
   }
 })
 
+const mockRunTask = vi.fn()
+vi.stubGlobal('runTask', mockRunTask)
+
 describe('playback.skipNext route', () => {
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -97,6 +100,7 @@ describe('playback.skipNext route', () => {
 
     await handler(event)
 
+    expect(mockRunTask).toHaveBeenCalledWith('playQueueRefresher')
     expect(mockPlayer.skipNext).toHaveBeenCalledTimes(1)
     expect(h3.setResponseHeaders).toHaveBeenCalledWith(
       event,

--- a/server/routes/player/playback/skipNext.get.ts
+++ b/server/routes/player/playback/skipNext.get.ts
@@ -28,6 +28,9 @@ export default eventHandler(async (event) => {
     const { playerInfo } = await usePlayerInfo(targetClientIdentifier)
     const { player } = await useSqueezePlayer(targetClientIdentifier)
 
+    // Plexamp does not always provide the full play queue in the beginning. (e.g track radio playQueue, is later populated on PMS), so we force refresh it here
+    // before skipping to next track to avoid skipping to "no track" on LMS and stopping playback
+    await runTask('playQueueRefresher')
     await player.skipNext()
     logger.info(`Player '${targetClientIdentifier}' skipped to next track`)
     setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))

--- a/server/routes/player/playback/skipTo.get.spec.ts
+++ b/server/routes/player/playback/skipTo.get.spec.ts
@@ -5,6 +5,7 @@ import usePlayerInfo from '../../../composables/usePlayerInfo'
 
 vi.mock('../../../composables/useLogger', () => ({
   default: () => ({
+    debug: (msg: string) => console.log(msg),
     info: (msg: string) => console.log(msg),
     warn: (msg: string) => console.log(msg),
     error: (msg: string) => console.log(msg)
@@ -200,7 +201,7 @@ describe('GET /server/routes/player/playback/skipTo.get', () => {
     expect(event.respondWith).not.toHaveBeenCalled()
   })
 
-  it.only('refresh playQueue and skips to track', async () => {
+  it('refresh playQueue and skips to track', async () => {
     // Mock headers and query
     ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
       const headers: Record<string, string> = {

--- a/server/routes/player/playback/skipTo.get.spec.ts
+++ b/server/routes/player/playback/skipTo.get.spec.ts
@@ -5,9 +5,9 @@ import usePlayerInfo from '../../../composables/usePlayerInfo'
 
 vi.mock('../../../composables/useLogger', () => ({
   default: () => ({
-    debug: vi.fn(),
-    warn: vi.fn(),
-    info: vi.fn()
+    info: (msg: string) => console.log(msg),
+    warn: (msg: string) => console.log(msg),
+    error: (msg: string) => console.log(msg)
   })
 }))
 
@@ -47,6 +47,9 @@ const mockGetItem = vi.fn()
 vi.stubGlobal('useStorage', () => ({
   getItem: mockGetItem
 }))
+
+const mockRunTask = vi.fn()
+vi.stubGlobal('runTask', mockRunTask)
 
 describe('GET /server/routes/player/playback/skipTo.get', () => {
   beforeEach(() => {
@@ -183,7 +186,6 @@ describe('GET /server/routes/player/playback/skipTo.get', () => {
         }
       }
     })
-    selectTrackInPlaylist.mockResolvedValue(undefined)
 
     const event: any = {
       node: { req: { headers: {} } },
@@ -192,7 +194,61 @@ describe('GET /server/routes/player/playback/skipTo.get', () => {
 
     await handler(event)
 
-    expect(selectTrackInPlaylist).toHaveBeenCalledWith(1)
+    expect(selectTrackInPlaylist).toHaveBeenCalledWith(1) // pq-2 is at index 1
+    expect(h3.setResponseHeaders as Mock).toHaveBeenCalledTimes(1)
+    expect(h3.sendNoContent as Mock).toHaveBeenCalledWith(event, 200)
+    expect(event.respondWith).not.toHaveBeenCalled()
+  })
+
+  it.only('refresh playQueue and skips to track', async () => {
+    // Mock headers and query
+    ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
+      const headers: Record<string, string> = {
+        'X-Plex-Target-Client-Identifier': 'player-1',
+        'X-Plex-Client-Identifier': 'client-1',
+        'X-Plex-Device-Name': 'Device'
+      }
+      return headers[name]
+    })
+    ;(h3.getQuery as Mock).mockReturnValue({
+      key: '/library/metadata/1',
+      commandID: 'cmd-99',
+      playQueueItemID: 'pq-4'
+    })
+    ;(usePlayerInfo as Mock).mockResolvedValue({
+      playerInfo: { playerid: 'player-1', name: 'Player One' },
+      serverStub: {}
+    })
+    // First call returns queue without pq-4, second call returns queue with pq-4 to simulate refresh
+    mockGetItem.mockResolvedValueOnce({
+      playQueue: {
+        MediaContainer: {
+          Track: [{ $: { playQueueItemID: 'pq-1' } }, { $: { playQueueItemID: 'pq-2' } }, { $: { playQueueItemID: 'pq-3' } }]
+        }
+      }
+    })
+    mockGetItem.mockResolvedValueOnce({
+      playQueue: {
+        MediaContainer: {
+          Track: [
+            { $: { playQueueItemID: 'pq-1' } },
+            { $: { playQueueItemID: 'pq-2' } },
+            { $: { playQueueItemID: 'pq-3' } },
+            { $: { playQueueItemID: 'pq-4' } }
+          ]
+        }
+      }
+    })
+
+    const event: any = {
+      node: { req: { headers: {} } },
+      respondWith: vi.fn()
+    }
+
+    await handler(event)
+
+    expect(mockRunTask).toHaveBeenCalledWith('playQueueRefresher')
+    expect(selectTrackInPlaylist).toHaveBeenCalledWith(3) // pq-4 is at index 3 (0-based)
     expect(h3.setResponseHeaders as Mock).toHaveBeenCalledTimes(1)
     expect(h3.sendNoContent as Mock).toHaveBeenCalledWith(event, 200)
     expect(event.respondWith).not.toHaveBeenCalled()

--- a/server/routes/player/playback/skipTo.get.ts
+++ b/server/routes/player/playback/skipTo.get.ts
@@ -67,7 +67,7 @@ export default eventHandler(async (event) => {
       }
 
       logger.info(
-        `Could not find track with playQueueItemID '${queryParameters.playQueueItemID} in loaded playerQueue, trying to refresh the playQueue from server ..`
+        `Could not find track with playQueueItemID '${queryParameters.playQueueItemID}' in loaded playerQueue, trying to refresh the playQueue from server ..`
       )
       // Plexamp does not always provide the full play queue in the beginning. (e.g track radio playQueue, is later populated on PMS), so we force refresh it here
       await runTask('playQueueRefresher')

--- a/server/routes/player/playback/skipTo.get.ts
+++ b/server/routes/player/playback/skipTo.get.ts
@@ -55,26 +55,28 @@ export default eventHandler(async (event) => {
     }
 
     async function resolveTrackIndexOrThrow(queue: PlayerPlayQueue): Promise<number> {
-      function isTrackIndexInvalid(index: number | undefined = maybeTrackIndex) {
-        return !index || index <= 0
+      
+      function isTrackIndexValid(index: number | undefined) {
+        return index !== undefined && index >= 0
       }
 
       const maybeTrackIndex = getTrackIndexByPlayQueueItemID(queue, queryParameters.playQueueItemID)
-      if (isTrackIndexInvalid(maybeTrackIndex)) {
-        logger.info(
-          `Could not find track with playQueueItemID '${queryParameters.playQueueItemID}' in loaded playerQueue, trying to refresh the playQueue from server ..`
-        )
-        // Plexamp does not always provide the full play queue in the beginning. (e.g track radio playQueue, is later populated on PMS), so we force refresh it here
-        await runTask('playQueueRefresher')
-        const refreshedPlayerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) || queue
-        const maybeRefreshedTrackIndex = getTrackIndexByPlayQueueItemID(refreshedPlayerQueue, queryParameters.playQueueItemID)
-        if (isTrackIndexInvalid(maybeRefreshedTrackIndex)) {
-          throw new Error(`Could not find track with playQueueItemID '${queryParameters.playQueueItemID}' in playerQueue, cannot skipTo`)
-        }
+      if (isTrackIndexValid(maybeTrackIndex)) {
+        logger.debug(`Resolved playQueueItemID '${queryParameters.playQueueItemID}' to playQueue index '${maybeTrackIndex}'`)
+        return maybeTrackIndex
+      }
+
+      logger.info(
+        `Could not find track with playQueueItemID '${queryParameters.playQueueItemID} in loaded playerQueue, trying to refresh the playQueue from server ..`
+      )
+      // Plexamp does not always provide the full play queue in the beginning. (e.g track radio playQueue, is later populated on PMS), so we force refresh it here
+      await runTask('playQueueRefresher')
+      const refreshedPlayerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? queue
+      const maybeRefreshedTrackIndex = getTrackIndexByPlayQueueItemID(refreshedPlayerQueue, queryParameters.playQueueItemID)
+      if (isTrackIndexValid(maybeRefreshedTrackIndex)) {
         return maybeRefreshedTrackIndex
       }
-      logger.debug(`Resolved playQueueItemID ${queryParameters.playQueueItemID} to playQueue index ${maybeTrackIndex}`)
-      return maybeTrackIndex
+      throw new Error(`Could not find track with playQueueItemID '${queryParameters.playQueueItemID}' in playerQueue, cannot skipTo`)
     }
 
     const trackIndex = await resolveTrackIndexOrThrow(playerQueue)

--- a/server/routes/player/playback/skipTo.get.ts
+++ b/server/routes/player/playback/skipTo.get.ts
@@ -14,21 +14,20 @@ export default eventHandler(async (event) => {
   const clientIdentifier = getRequestHeader(event, 'X-Plex-Client-Identifier')
   const deviceName = getRequestHeader(event, 'X-Plex-Device-Name')
 
-  logger.info(`SkipTo request received for player '${targetClientIdentifier}' with query: ${JSON.stringify(query)}`)
   const queryParameters = {
     key: query.key as string,
     commandID: query.commandID as string,
     playQueueItemID: query.playQueueItemID as string
   }
 
-  if (!targetClientIdentifier || !clientIdentifier || !deviceName) {
+  if (!targetClientIdentifier || !clientIdentifier || !deviceName || !queryParameters.playQueueItemID) {
     logger.warn(
-      `Missing required parameters ('X-Plex-Target-Client-Identifier', 'X-Plex-Client-Identifier', 'X-Plex-Device-Name' headers), got:`,
+      `Missing required parameters ('X-Plex-Target-Client-Identifier', 'X-Plex-Client-Identifier', 'X-Plex-Device-Name' headers) or query parameter playQueueItemID got:`,
       event.node.req.headers
     )
     return event.respondWith(
       new Response(
-        `Missing required parameters ('X-Plex-Target-Client-Identifier', 'X-Plex-Client-Identifier', 'X-Plex-Device-Name' headers)`,
+        `Missing required parameters ('X-Plex-Target-Client-Identifier', 'X-Plex-Client-Identifier', 'X-Plex-Device-Name' headers) or query parameter playQueueItemID`,
         { status: 400 }
       )
     )
@@ -44,17 +43,41 @@ export default eventHandler(async (event) => {
       return
     }
 
+    /**
+     * Get the index of a track in the play queue by its playQueueItemID
+     * @param queue current player queue
+     * @param playQueueItemID the playQueueItemID of the track
+     * @returns -1 if not found, otherwise the 0-based index of the item in the play queue
+     */
     function getTrackIndexByPlayQueueItemID(queue: PlayerPlayQueue, playQueueItemID: string): number {
       const tracks = queue.playQueue?.MediaContainer?.Track ?? []
       return tracks.findIndex((t) => t.$.playQueueItemID === playQueueItemID)
     }
 
-    const trackIndex = getTrackIndexByPlayQueueItemID(playerQueue, queryParameters.playQueueItemID)
-    logger.debug(`Resolved playQueueItemID ${queryParameters.playQueueItemID} to playQueue index ${trackIndex}`)
-    if (trackIndex < 0) {
-      throw new Error(`Could not find track with playQueueItemID ${queryParameters.playQueueItemID} in playerQueue, cannot skipTo`)
+    async function resolveTrackIndexOrThrow(queue: PlayerPlayQueue): Promise<number> {
+      function isTrackIndexInvalid(index: number | undefined = maybeTrackIndex) {
+        return !index || index <= 0
+      }
+
+      const maybeTrackIndex = getTrackIndexByPlayQueueItemID(queue, queryParameters.playQueueItemID)
+      if (isTrackIndexInvalid(maybeTrackIndex)) {
+        logger.info(
+          `Could not find track with playQueueItemID '${queryParameters.playQueueItemID}' in loaded playerQueue, trying to refresh the playQueue from server ..`
+        )
+        // Plexamp does not always provide the full play queue in the beginning. (e.g track radio playQueue, is later populated on PMS), so we force refresh it here
+        await runTask('playQueueRefresher')
+        const refreshedPlayerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) || queue
+        const maybeRefreshedTrackIndex = getTrackIndexByPlayQueueItemID(refreshedPlayerQueue, queryParameters.playQueueItemID)
+        if (isTrackIndexInvalid(maybeRefreshedTrackIndex)) {
+          throw new Error(`Could not find track with playQueueItemID '${queryParameters.playQueueItemID}' in playerQueue, cannot skipTo`)
+        }
+        return maybeRefreshedTrackIndex
+      }
+      logger.debug(`Resolved playQueueItemID ${queryParameters.playQueueItemID} to playQueue index ${maybeTrackIndex}`)
+      return maybeTrackIndex
     }
 
+    const trackIndex = await resolveTrackIndexOrThrow(playerQueue)
     await player.selectTrackInPlaylist(trackIndex) // LMS wants a 0-based index here
     logger.info(`Player '${targetClientIdentifier}' skipped to playlist item ${trackIndex}`)
     setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))

--- a/server/tasks/playQueueRefresher.spec.ts
+++ b/server/tasks/playQueueRefresher.spec.ts
@@ -1,0 +1,131 @@
+import type { Mock } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { runPlayQueueRefresher } from './playQueueRefresher'
+import { getPlayQueue } from '../lib/plexApi'
+
+vi.mock('../composables/useLogger', () => {
+  const wrap = (level: string) =>
+    vi.fn((...args: any[]) => {
+      console.log(`[logger:${level}]`, ...args)
+    })
+
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      info: wrap('info'),
+      warn: wrap('warn'),
+      error: wrap('error'),
+      debug: wrap('debug')
+    }))
+  }
+})
+
+// Mock useSqueezePlayer
+const mockAddToPlaylist = vi.fn()
+
+vi.mock('../composables/useSqueezePlayer', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    player: { addToPlaylist: mockAddToPlaylist }
+  }))
+}))
+
+
+// Mock plexApi
+vi.mock('../lib/plexApi', () => {
+  const getPlayQueue = vi.fn()
+  const getPlexApiTrack = vi.fn().mockReturnValue('http://track.url')
+  const metadata = vi.fn().mockReturnValue('meta')
+  return {
+    getPlayQueue,
+    getPlexApiTrack,
+    metadata
+  }
+})
+
+// Mock storage
+const storageMock = {
+  getKeys: vi.fn(),
+  getItem: vi.fn(),
+  setItem: vi.fn()
+}
+vi.stubGlobal('useStorage', () => storageMock)
+
+describe('runPlayQueueRefresher', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storageMock.getKeys.mockReset()
+    storageMock.getItem.mockReset()
+    storageMock.setItem.mockReset()
+    mockAddToPlaylist.mockReset()
+    ;(getPlayQueue as Mock).mockReset()
+  })
+
+  it('skips if no players found', async () => {
+    storageMock.getKeys.mockResolvedValue([])
+    await runPlayQueueRefresher()
+    expect(storageMock.getKeys).toHaveBeenCalledWith('players/')
+    expect(storageMock.getItem).not.toHaveBeenCalled()
+    expect(mockAddToPlaylist).not.toHaveBeenCalled()
+  })
+
+  it('skips if no playerQueue found', async () => {
+    storageMock.getKeys.mockResolvedValue(['players/server1'])
+    storageMock.getItem.mockResolvedValueOnce([{ playerid: 'p1', name: 'Player 1' }])
+    storageMock.getItem.mockResolvedValueOnce(undefined) // playerQueue
+    await runPlayQueueRefresher()
+    expect(storageMock.getItem).toHaveBeenCalledWith('players/server1')
+    expect(mockAddToPlaylist).not.toHaveBeenCalled()
+  })
+
+  it('adds new tracks if playQueue size increased', async () => {
+    storageMock.getKeys.mockResolvedValue(['players/server1'])
+    storageMock.getItem.mockResolvedValueOnce([{ playerid: 'p1', name: 'Player 1' }])
+    storageMock.getItem.mockResolvedValueOnce({
+      playerid: 'p1',
+      playQueue: {
+        MediaContainer: {
+          $: { playQueueID: 'pqid', size: '1' },
+          Track: [{ $: { title: 'Old Track', key: 'old' } }]
+        }
+      },
+      plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
+    })
+    ;(getPlayQueue as Mock).mockResolvedValue({
+      MediaContainer: {
+        $: { playQueueID: 'pqid', size: '2' },
+        Track: [{ $: { title: 'Old Track', key: 'old' } }, { $: { title: 'New Track', key: 'new' } }]
+      }
+    })
+    await runPlayQueueRefresher()
+    expect(mockAddToPlaylist).toHaveBeenCalledWith('http://track.url', 'meta')
+    expect(storageMock.setItem).toHaveBeenCalledWith('playerQueue/p1', expect.anything())
+  })
+
+  it('skips if playQueue size unchanged', async () => {
+    storageMock.getKeys.mockResolvedValue(['players/server1'])
+    storageMock.getItem.mockResolvedValueOnce([{ playerid: 'p1', name: 'Player 1' }])
+    storageMock.getItem.mockResolvedValueOnce({
+      playerid: 'p1',
+      playQueue: {
+        MediaContainer: {
+          $: { playQueueID: 'pqid', size: '1' },
+          Track: [{ $: { title: 'Old Track', key: 'old' } }]
+        }
+      },
+      plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
+    })
+    ;(getPlayQueue as Mock).mockResolvedValue({
+      MediaContainer: {
+        $: { playQueueID: 'pqid', size: '1' },
+        Track: [{ $: { title: 'Old Track', key: 'old' } }]
+      }
+    })
+    await runPlayQueueRefresher()
+    expect(mockAddToPlaylist).not.toHaveBeenCalled()
+    expect(storageMock.setItem).not.toHaveBeenCalled()
+  })
+
+  it('handles errors gracefully', async () => {
+    storageMock.getKeys.mockRejectedValue(new Error('fail'))
+    await expect(runPlayQueueRefresher()).resolves.toBeUndefined()
+  })
+})

--- a/server/tasks/playQueueRefresher.ts
+++ b/server/tasks/playQueueRefresher.ts
@@ -94,11 +94,11 @@ export async function runPlayQueueRefresher() {
         await storage.setItem(`playerQueue/${playerInfo.playerid}`, refreshedPlayerQueue)
 
         logger.info(
-          `Player '${playerInfo.name}' (${playerInfo.playerid}): playQueue '${playQueueId}' size changed from ${playerQueue.playQueue.MediaContainer.$.size} to ${refreshedPlayQueue.MediaContainer.$.size} tracks.`
+          `Player '${playerInfo.name}' (${playerInfo.playerid}): playQueue '${playQueueId}' size changed from '${playerQueue.playQueue.MediaContainer.$.size}' to '${refreshedPlayQueue.MediaContainer.$.size}' tracks.`
         )
       })
     )
   } catch (error) {
-    logger.error(`Error when refreshing play queues`, error)
+    logger.error(`Error when refreshing play queues ${error}`, error)
   }
 }

--- a/server/tasks/playQueueRefresher.ts
+++ b/server/tasks/playQueueRefresher.ts
@@ -1,9 +1,23 @@
+/**
+ * Nitro task that refreshes the Plex play queue for all Squeeze players.
+ *
+ * This task iterates through all discovered Squeeze players stored in the DISCOVERY storage,
+ * checks for updates to their associated Plex play queues, and updates the queues if changes are detected.
+ * If new tracks are found in the refreshed play queue, they are added to the player's playlist.
+ *
+ * Can be manually triggered in dev mode via: http://localhost:3000/_nitro/tasks/playQueueRefresher
+ *
+ * @returns An object indicating the result of the refresh operation.
+ */
 import type { IPlayerInfo } from 'lms-squeeze-rpc-x/dist/modelTypes'
 import useLogger from '../composables/useLogger'
 import useSqueezePlayer from '../composables/useSqueezePlayer'
 import { getPlayQueue, metadata, getPlexApiTrack } from '../lib/plexApi'
 import type { PlayerPlayQueue } from '../lib/plexPlayerTimeline'
 
+/**
+ * Manually trigger the refresh: http://localhost:3000/_nitro/tasks/playQueueRefresher
+ */
 export default defineTask({
   meta: {
     name: 'playQueueRefresher',
@@ -63,7 +77,6 @@ export async function runPlayQueueRefresher() {
           plexServer: playerQueue.plexServer
         }
 
-        // check if the playQueue has changed in size
         if (refreshedPlayQueue.MediaContainer.$.size === playerQueue.playQueue.MediaContainer.$.size) {
           logger.info(
             `PlayQueue '${playQueueId}' of player ${playerInfo.playerid} has not changed in size (${refreshedPlayQueue.MediaContainer.$.size} items), skipping`
@@ -71,28 +84,9 @@ export async function runPlayQueueRefresher() {
           return
         }
 
-        //logger.info(JSON.stringify(refreshedPlayQueue))
-
-        const playerStatus = await player.status()
-        if (!playerStatus) {
-          throw new Error(`Could not get status from player '${playerInfo.name}', cannot refresh play queue`)
-        }
-        const currentPlaylistIndex = playerStatus?.playlist_cur_index
-        const playlistTrackCount = playerStatus?.playlist_tracks
-
-        logger.info(
-          `Cleaning up existing playQueue in player '${playerInfo.name}' from index ${currentPlaylistIndex + 1} to ${playlistTrackCount} to prepare for playQueue refresh ..`
-        )
-
-        // TODO is this necessary in this case or can we just add the missing tracks to the end of the queue?
-        for (let trackIndex = playlistTrackCount - 1; trackIndex > currentPlaylistIndex; trackIndex--) {
-          await player.deleteTrackFromPlaylist(trackIndex)
-        }
-
-        const selectedOffset = Number(refreshedPlayQueue.MediaContainer.$.playQueueSelectedItemOffset)
-        const tracks = refreshedPlayQueue.MediaContainer.Track.slice(selectedOffset + 1)
-        for (const track of tracks) {
-          logger.info(`Adding track '${track.$.title}' to refreshed playQueue for player '${playerInfo.name}' ..`)
+        const updatedTrackQueue = refreshedPlayQueue.MediaContainer.Track.slice(Number(playerQueue.playQueue.MediaContainer.$.size))
+        for (const track of updatedTrackQueue) {
+          logger.info(`Adding track '${track.$.title}' / '${track.$.key}' to refreshed playQueue for player '${playerInfo.name}' ..`)
           const trackUrl = getPlexApiTrack(playerQueue.plexServer, track)
           await player.addToPlaylist(trackUrl, metadata(track))
         }
@@ -100,11 +94,11 @@ export async function runPlayQueueRefresher() {
         await storage.setItem(`playerQueue/${playerInfo.playerid}`, refreshedPlayerQueue)
 
         logger.info(
-          `Refreshed playQueue '${playQueueId}' of player ${playerInfo.playerid}, now has ${refreshedPlayQueue.MediaContainer.$.size} items`
+          `Player '${playerInfo.name}' (${playerInfo.playerid}): playQueue '${playQueueId}' size changed from ${playerQueue.playQueue.MediaContainer.$.size} to ${refreshedPlayQueue.MediaContainer.$.size} tracks.`
         )
       })
     )
   } catch (error) {
-    logger.error(`Error when refreshing player play queues`, error)
+    logger.error(`Error when refreshing play queues`, error)
   }
 }

--- a/server/tasks/playQueueRefresher.ts
+++ b/server/tasks/playQueueRefresher.ts
@@ -1,6 +1,6 @@
 import useLogger from '../composables/useLogger'
-import { SqueezeServerStub, SqueezeServer } from 'lms-squeeze-rpc-x'
-import type { ServerInfo } from 'lms-discovery'
+import useSqueezePlayer from '../composables/useSqueezePlayer'
+import { getPlayQueue, metadata, getPlexApiTrack } from '../lib/plexApi'
 
 export default defineTask({
   meta: {
@@ -20,7 +20,7 @@ export async function runPlayQueueRefresher() {
   const logger = useLogger('playQueueRefresher')
   const storage = useStorage('DISCOVERY')
   try {
-    logger.debug('Refreshing Plex play queues for all Squeeze players ..')
+    logger.info('Refreshing Plex play queues for all Squeeze players ..')
 
     const serverKeys = await storage.getKeys('players/')
     if (!serverKeys || serverKeys.length === 0) {
@@ -42,28 +42,67 @@ export async function runPlayQueueRefresher() {
     }
 
     await Promise.all(
-      allPlayers.map(async ([serverId, playerInfo]) => {
-        // resolve player status and send timeline to all subscribers
-        logger.debug(`Publishing timeline to ${playerSubscribers.length} subscribers for player ${playerInfo.playerid} ..`)
-        const serverInfo = await storage.getItem<ServerInfo>(`servers/${serverId}`)
-        if (!serverInfo || !serverInfo.ip) {
-          throw new Error(`SqueezeServerStub not found in storage for player '${playerInfo.playerid}'`)
-        }
+      allPlayers.map(async ([_serverId, playerInfo]) => {
         const { player } = await useSqueezePlayer(playerInfo.playerid)
-
-        const playerStatus = await player.status()
-        if (!playerStatus) {
-          throw new Error(`Player ${playerInfo.playerid} status available yet`)
-        }
 
         const playerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? undefined
         if (!playerQueue) {
-          logger.debug(`No playerQueue available for player ${playerInfo.playerid}, skipping play queue update`)
+          logger.info(`No playQueue available for player ${playerInfo.playerid}, skipping refresh`)
           return
         }
+
+        const playQueueId = playerQueue.playQueue.MediaContainer.$.playQueueID
+
+        logger.info(`Refreshing playQueue '${playQueueId}' of player ${playerInfo.playerid} ..`)
+        const refreshedPlayQueue = await getPlayQueue(playerQueue.plexServer, `/playQueues/${playQueueId}`)
+        const refreshedPlayerQueue: PlayerPlayQueue = {
+          playerId: playerInfo.playerid,
+          playQueue: refreshedPlayQueue,
+          plexServer: playerQueue.plexServer
+        }
+
+        // check if the playQueue has changed in size
+        if (refreshedPlayQueue.MediaContainer.$.size === playerQueue.playQueue.MediaContainer.$.size) {
+          logger.info(
+            `PlayQueue '${playQueueId}' of player ${playerInfo.playerid} has not changed in size (${refreshedPlayQueue.MediaContainer.$.size} items), skipping`
+          )
+          return
+        }
+
+        //logger.info(JSON.stringify(refreshedPlayQueue))
+
+        const playerStatus = await player.status()
+        if (!playerStatus) {
+          throw new Error(`Could not get status from player '${playerInfo.name}', cannot refresh play queue`)
+        }
+        const currentPlaylistIndex = playerStatus?.playlist_cur_index
+        const playlistTrackCount = playerStatus?.playlist_tracks
+
+        logger.info(
+          `Cleaning up existing playQueue in player '${playerInfo.name}' from index ${currentPlaylistIndex + 1} to ${playlistTrackCount} to prepare for playQueue refresh ..`
+        )
+
+        // TODO is this necessary in this case or can we just add the missing tracks to the end of the queue?
+        for (let trackIndex = playlistTrackCount - 1; trackIndex > currentPlaylistIndex; trackIndex--) {
+          await player.deleteTrackFromPlaylist(trackIndex)
+        }
+
+        const selectedOffset = Number(refreshedPlayQueue.MediaContainer.$.playQueueSelectedItemOffset)
+        const tracks = refreshedPlayQueue.MediaContainer.Track.slice(selectedOffset + 1)
+        for (const track of tracks) {
+          logger.info(`Adding track '${track.$.title}' to refreshed playQueue for player '${playerInfo.name}' ..`)
+          const trackUrl = getPlexApiTrack(playerQueue.plexServer, track)
+          await player.addToPlaylist(trackUrl, metadata(track))
+        }
+
+        await storage.setItem(`playerQueue/${playerInfo.playerid}`, refreshedPlayerQueue)
+
+        logger.info(
+          `Refreshed playQueue '${playQueueId}' of player ${playerInfo.playerid}, now has ${refreshedPlayQueue.MediaContainer.$.size} items`
+        )
       })
     )
   } catch (error) {
-    logger.error(`Error when updating player play queues`, error)
+    logger.error(`Error when refreshing player play queues`, error)
   }
 }

--- a/server/tasks/playQueueRefresher.ts
+++ b/server/tasks/playQueueRefresher.ts
@@ -49,7 +49,7 @@ export async function runPlayQueueRefresher() {
     for (const key of serverKeys) {
       const playerInfos = await storage.getItem<IPlayerInfo[]>(key)
       logger.debug(`Found ${playerInfos?.length || 0} players for server '${key}'`)
-      const serverId = key.split(':')[1] // e.g. players:de443cee-943b-421a-8db3-575e5b4cddc6 where the later is the serverId
+      const serverId = key.split(':')[1]
       if (playerInfos) {
         for (const player of playerInfos) {
           allPlayers.push([serverId, player])
@@ -63,13 +63,13 @@ export async function runPlayQueueRefresher() {
 
         const playerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? undefined
         if (!playerQueue) {
-          logger.info(`No playQueue available for player ${playerInfo.playerid}, skipping refresh`)
+          logger.info(`No playQueue available for player '${playerInfo.name}' (${playerInfo.playerid}), skipping refresh`)
           return
         }
 
         const playQueueId = playerQueue.playQueue.MediaContainer.$.playQueueID
 
-        logger.info(`Refreshing playQueue '${playQueueId}' of player ${playerInfo.playerid} ..`)
+        logger.info(`Refreshing playQueue '${playQueueId}' of player '${playerInfo.name}' (${playerInfo.playerid}) ..`)
         const refreshedPlayQueue = await getPlayQueue(playerQueue.plexServer, `/playQueues/${playQueueId}`)
         const refreshedPlayerQueue: PlayerPlayQueue = {
           playerId: playerInfo.playerid,
@@ -79,14 +79,14 @@ export async function runPlayQueueRefresher() {
 
         if (refreshedPlayQueue.MediaContainer.$.size === playerQueue.playQueue.MediaContainer.$.size) {
           logger.info(
-            `PlayQueue '${playQueueId}' of player ${playerInfo.playerid} has not changed in size (${refreshedPlayQueue.MediaContainer.$.size} items), skipping`
+            `PlayQueue '${playQueueId}' of player '${playerInfo.name}' (${playerInfo.playerid}) has not changed in size (${refreshedPlayQueue.MediaContainer.$.size} items), skipping`
           )
           return
         }
 
         const updatedTrackQueue = refreshedPlayQueue.MediaContainer.Track.slice(Number(playerQueue.playQueue.MediaContainer.$.size))
         for (const track of updatedTrackQueue) {
-          logger.info(`Adding track '${track.$.title}' / '${track.$.key}' to refreshed playQueue for player '${playerInfo.name}' ..`)
+          logger.info(`Adding track '${track.$.title}' / '${track.$.key}' to refreshed playQueue for player '${playerInfo.name}' (${playerInfo.playerid}) ..`)
           const trackUrl = getPlexApiTrack(playerQueue.plexServer, track)
           await player.addToPlaylist(trackUrl, metadata(track))
         }

--- a/server/tasks/playQueueRefresher.ts
+++ b/server/tasks/playQueueRefresher.ts
@@ -1,6 +1,8 @@
+import type { IPlayerInfo } from 'lms-squeeze-rpc-x/dist/modelTypes'
 import useLogger from '../composables/useLogger'
 import useSqueezePlayer from '../composables/useSqueezePlayer'
 import { getPlayQueue, metadata, getPlexApiTrack } from '../lib/plexApi'
+import type { PlayerPlayQueue } from '../lib/plexPlayerTimeline'
 
 export default defineTask({
   meta: {

--- a/server/tasks/playQueueRefresher.ts
+++ b/server/tasks/playQueueRefresher.ts
@@ -1,0 +1,69 @@
+import useLogger from '../composables/useLogger'
+import { SqueezeServerStub, SqueezeServer } from 'lms-squeeze-rpc-x'
+import type { ServerInfo } from 'lms-discovery'
+
+export default defineTask({
+  meta: {
+    name: 'playQueueRefresher',
+    description: 'Refreshes the Plex play queue for all Squeeze players'
+  },
+  async run(_event) {
+    await runPlayQueueRefresher()
+    return { result: 'ok' }
+  }
+})
+
+/**
+ * Checks for Plex (PMS) play queue updates and stores them in the DISCOVERY storage.
+ */
+export async function runPlayQueueRefresher() {
+  const logger = useLogger('playQueueRefresher')
+  const storage = useStorage('DISCOVERY')
+  try {
+    logger.debug('Refreshing Plex play queues for all Squeeze players ..')
+
+    const serverKeys = await storage.getKeys('players/')
+    if (!serverKeys || serverKeys.length === 0) {
+      logger.debug('No LMS found in storage, skipping')
+      return
+    }
+
+    const allPlayers: [string, IPlayerInfo][] = [] // Array of tuples (serverId, IPlayerInfo)
+
+    for (const key of serverKeys) {
+      const playerInfos = await storage.getItem<IPlayerInfo[]>(key)
+      logger.debug(`Found ${playerInfos?.length || 0} players for server '${key}'`)
+      const serverId = key.split(':')[1] // e.g. players:de443cee-943b-421a-8db3-575e5b4cddc6 where the later is the serverId
+      if (playerInfos) {
+        for (const player of playerInfos) {
+          allPlayers.push([serverId, player])
+        }
+      }
+    }
+
+    await Promise.all(
+      allPlayers.map(async ([serverId, playerInfo]) => {
+        // resolve player status and send timeline to all subscribers
+        logger.debug(`Publishing timeline to ${playerSubscribers.length} subscribers for player ${playerInfo.playerid} ..`)
+        const serverInfo = await storage.getItem<ServerInfo>(`servers/${serverId}`)
+        if (!serverInfo || !serverInfo.ip) {
+          throw new Error(`SqueezeServerStub not found in storage for player '${playerInfo.playerid}'`)
+        }
+        const { player } = await useSqueezePlayer(playerInfo.playerid)
+
+        const playerStatus = await player.status()
+        if (!playerStatus) {
+          throw new Error(`Player ${playerInfo.playerid} status available yet`)
+        }
+
+        const playerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? undefined
+        if (!playerQueue) {
+          logger.debug(`No playerQueue available for player ${playerInfo.playerid}, skipping play queue update`)
+          return
+        }
+      })
+    )
+  } catch (error) {
+    logger.error(`Error when updating player play queues`, error)
+  }
+}

--- a/server/tasks/squeezePlayersScanner.spec.ts
+++ b/server/tasks/squeezePlayersScanner.spec.ts
@@ -23,13 +23,6 @@ vi.stubGlobal('useStorage', () => ({
   getItem: mockGetItem
 }))
 
-const mockScheduler = {
-  run: vi.fn(function () {
-    return mockScheduler
-  }),
-  everySeconds: vi.fn()
-}
-
 // Mock composables
 vi.mock('lms-squeeze-rpc-x', async () => {
   const actual = await vi.importActual<any>('lms-squeeze-rpc-x')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {  
-  "extends": "./.nuxt/tsconfig.json"
+  "extends": "./.nuxt/tsconfig.server.json"
 }


### PR DESCRIPTION
This pull request introduces a new scheduled background task, `playQueueRefresher`, to improve the reliability of play queue synchronization between Plex and LMS players, especially for scenarios where the play queue is updated asynchronously (such as with Plexamp's radio feature). It also updates the playback skip routes to ensure the play queue is refreshed as needed, adds comprehensive tests for the new task, and cleans up some legacy code and minor bugs.

**Key changes:**

### Play Queue Synchronization Improvements

* Added a new scheduled task, `playQueueRefresher`, to the Nitro scheduled tasks configuration, ensuring play queues are refreshed every minute.
* Implemented and thoroughly tested the `runPlayQueueRefresher` function, which detects when new tracks have been added to a Plex play queue and ensures the LMS playlist stays in sync.

### Playback Route Enhancements

* Updated the `skipNext` and `skipTo` playback routes to invoke `runTask('playQueueRefresher')` before attempting to skip tracks. This prevents playback issues when the queue is not fully populated yet (e.g., with Plexamp radio). [[1]](diffhunk://#diff-a25079773cddc2ebc73e584c32e19f3cef68dc652f3dde43ea05437adb4a4b98R31-R33) [[2]](diffhunk://#diff-79ac673cf6ab1604620918d5ff410f9f62ab04004c8ac7dbd23cb469186180bbR46-R80)
* Improved the logic in `skipTo` to retry fetching the play queue if the requested track is not found, and to return a more descriptive error if the track is still missing.
