### PR TITLE
#64 improve refresh play queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "format": "prettier --write app/** server/**"
   },
   "dependencies": {
-    "@nuxt/kit": "^4.1.3",
-    "@nuxt/ui": "^4.0.1",
+    "@nuxt/kit": "^4.2.0",
+    "@nuxt/ui": "^4.1.0",
     "axios": "^1.12.0",
     "lms-discovery": "^1.1.0",
     "lms-squeeze-rpc-x": "1.1.0",

--- a/server/routes/player/playback/createPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/createPlayQueue.get.spec.ts
@@ -166,8 +166,6 @@ describe('playback.createPlayQueue route', () => {
     expect(mockPlayer.addToPlaylist).toHaveBeenCalledTimes(2)
     // Assert that selectTrackInPlaylist is called with the correct offset
     expect(mockPlayer.selectTrackInPlaylist).toHaveBeenCalledWith(4)
-    // Assert that play is called after adding tracks and selecting track
-    expect(mockPlayer.play).toHaveBeenCalledTimes(1)
 
     expect(h3.setResponseHeaders).toHaveBeenCalledWith(
       event,

--- a/server/routes/player/playback/createPlayQueue.get.ts
+++ b/server/routes/player/playback/createPlayQueue.get.ts
@@ -126,7 +126,6 @@ export default eventHandler(async (event) => {
       await player.addToPlaylist(trackUrl, metadata(meta))
     }
     await player.selectTrackInPlaylist(Number(playQueue.MediaContainer.$.playQueueSelectedItemOffset))
-    await player.play()
     logger.info(
       `Playing playlist index '${playQueue.MediaContainer.$.playQueueSelectedItemOffset}' on player '${playerInfo.name} / ${playerInfo.playerid}'`
     )

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import * as h3 from 'h3'
 import handler from './refreshPlayQueue.get'
 import { getPlayQueue } from '../../../lib/plexApi'
-import { tr } from '@nuxt/ui/runtime/locale/index.js'
 
 vi.mock('../../../composables/useLogger', () => {
   const wrap = (level: string) =>

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import * as h3 from 'h3'
 import handler from './refreshPlayQueue.get'
 import { getPlayQueue } from '../../../lib/plexApi'
+import { tr } from '@nuxt/ui/runtime/locale/index.js'
 
 vi.mock('../../../composables/useLogger', () => {
   const wrap = (level: string) =>
@@ -146,6 +147,8 @@ describe('playback.refreshPlayQueue route', () => {
       },
       plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
     })
+    // simulate pending lock active
+    getItemMock.mockResolvedValueOnce(true)
     // new play queue after refresh, missing first two tracks with two others queued
     ;(getPlayQueue as Mock).mockResolvedValueOnce({
       MediaContainer: {
@@ -194,7 +197,8 @@ describe('playback.refreshPlayQueue route', () => {
     expect(h3.setResponseHeaders).toHaveBeenCalledWith(event, expect.anything())
     expect(h3.sendNoContent).toHaveBeenCalledWith(event, 200)
     expect(event.respondWith).not.toHaveBeenCalledWith(expect.any(Response))
-    expect(removeItemMock).toHaveBeenCalled()
+    expect(removeItemMock).toHaveBeenCalledWith('refreshPlayQueueLock/player-1/pending')
+    expect(removeItemMock).toHaveBeenCalledWith('refreshPlayQueueLock/player-1')
   })
 
   it('returns 404 if play queue update is locked', async () => {

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -200,6 +200,22 @@ describe('playback.refreshPlayQueue route', () => {
     expect(removeItemMock).toHaveBeenCalled()
   })
 
+  it('returns 404 if play queue update is locked', async () => {
+    ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
+      return mockHeaders[name]
+    })
+    
+    getItemMock.mockResolvedValueOnce(new Date())
+
+    await handler(event)
+    expect(setItemMock).toHaveBeenCalledWith('refreshPlayQueueLock/player-1/pending', true)
+    expect(event.respondWith).toHaveBeenCalledTimes(1)
+    const resp: Response = event.respondWith.mock.calls[0][0]
+    expect(resp.status).toBe(404)
+    expect(h3.sendNoContent).not.toHaveBeenCalled()
+    expect(removeItemMock).not.toHaveBeenCalled()
+  })
+
   it('returns 404 when player status fails', async () => {
     ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
       return mockHeaders[name]

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -186,12 +186,10 @@ describe('playback.refreshPlayQueue route', () => {
     )
     await handler(event)
     // delete the first two tracks
-    //expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledTimes(2)
+    expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledTimes(3)
     expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(0)
     expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(1)
     expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(3)
-    //expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(4)
-    //expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(5)
     // add all the tracks after the current, now updated index which is 0 after we deleted the first two tracks to reflect refreshed queue
     expect(mockPlayer.addToPlaylist).toHaveBeenCalledTimes(3)
     expect(mockPlayer.addToPlaylist).toHaveBeenCalledWith('http://10.10.1.1/track1', 'metadata-string') // statically mocked input

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 import * as h3 from 'h3'
 import handler from './refreshPlayQueue.get'
+import { getPlayQueue } from '../../../lib/plexApi'
 
 vi.mock('../../../composables/useLogger', () => {
   const wrap = (level: string) =>
@@ -23,9 +24,8 @@ vi.mock('../../../composables/usePlayerInfo', () => ({
   default: vi.fn(async () => ({ playerInfo: playerInfoMock }))
 }))
 
-const playerStatusMock = { playlist_cur_index: 1, playlist_tracks: 3 }
 const mockPlayer = {
-  status: vi.fn().mockResolvedValue(playerStatusMock),
+  status: vi.fn(),
   deleteTrackFromPlaylist: vi.fn().mockResolvedValue(undefined),
   addToPlaylist: vi.fn().mockResolvedValue(undefined)
 }
@@ -35,10 +35,12 @@ vi.mock('../../../composables/useSqueezePlayer', () => ({
 
 const setItemMock = vi.fn()
 const getItemMock = vi.fn()
+const removeItemMock = vi.fn()
 function useStorage() {
   return {
     setItem: setItemMock,
-    getItem: getItemMock
+    getItem: getItemMock,
+    removeItem: removeItemMock
   }
 }
 vi.stubGlobal('useStorage', useStorage)
@@ -50,15 +52,7 @@ vi.mock('../../../lib/plexApi', () => ({
     h.set('X-Plex-Player-Name', name)
     return h
   }),
-  getPlayQueue: vi.fn().mockResolvedValue({
-    MediaContainer: {
-      $: { playQueueSelectedItemOffset: '0' },
-      Track: [
-        { $: { title: 'Track 1' }, Media: [{ Part: [{ $: { key: '1' } }] }] },
-        { $: { title: 'Track 2' }, Media: [{ Part: [{ $: { key: '2' } }] }] }
-      ]
-    }
-  }),
+  getPlayQueue: vi.fn(),
   getPlexApiTrack: vi.fn().mockReturnValue('http://10.10.1.1/track1'),
   metadata: vi.fn().mockReturnValue('metadata-string')
 }))
@@ -92,9 +86,9 @@ describe('playback.refreshPlayQueue route', () => {
     vi.clearAllMocks()
     getItemMock.mockReset()
     setItemMock.mockReset()
-    mockPlayer.status.mockResolvedValue(playerStatusMock)
-    mockPlayer.deleteTrackFromPlaylist.mockResolvedValue(undefined)
-    mockPlayer.addToPlaylist.mockResolvedValue(undefined)
+    // mockPlayer.status.mockResolvedValue(playerStatusMock)
+    // mockPlayer.deleteTrackFromPlaylist.mockResolvedValue(undefined)
+    // mockPlayer.addToPlaylist.mockResolvedValue(undefined)
   })
 
   it('returns 400 when required headers or playQueueID are missing', async () => {
@@ -110,7 +104,8 @@ describe('playback.refreshPlayQueue route', () => {
     ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
       return mockHeaders[name]
     })
-    getItemMock.mockResolvedValue(undefined)
+    getItemMock.mockResolvedValueOnce(undefined)
+    getItemMock.mockResolvedValueOnce(undefined)
     await handler(event)
     expect(getItemMock).toHaveBeenCalled()
     expect(mockPlayer.deleteTrackFromPlaylist).not.toHaveBeenCalled()
@@ -119,33 +114,100 @@ describe('playback.refreshPlayQueue route', () => {
     const resp: Response = event.respondWith.mock.calls[0][0]
     expect(resp.status).toBe(404)
     expect(h3.setResponseHeaders).not.toHaveBeenCalled()
+    expect(removeItemMock).toHaveBeenCalled()
   })
 
   it('refreshes play queue and updates playlist', async () => {
     ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
       return mockHeaders[name]
     })
-    getItemMock.mockResolvedValue({
+    getItemMock.mockResolvedValueOnce(undefined)
+    // existing playerQueue before refresh
+    getItemMock.mockResolvedValueOnce({
       playerId: playerInfoMock.playerid,
-      playQueue: {},
+      playQueue: {
+        MediaContainer: {
+          Track: [
+            {
+              $: { playQueueItemID: 'pq-1', title: 'Track 1' },
+              Media: [{ Part: [{ $: { key: 'track1url.flac' } }] }]
+            },
+            {
+              $: { playQueueItemID: 'pq-2', title: 'Track 2' },
+              Media: [{ Part: [{ $: { key: 'track2url.flac' } }] }]
+            },
+            {
+              $: { playQueueItemID: 'pq-3', title: 'Track 3' },
+              Media: [{ Part: [{ $: { key: 'track3url.flac' } }] }]
+            },
+            {
+              $: { playQueueItemID: 'pq-4', title: 'Track 4' },
+              Media: [{ Part: [{ $: { key: 'track4url.flac' } }] }]
+            }
+          ]
+        }
+      },
       plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
     })
+    // new play queue after refresh, missing first two tracks with two others queued
+    ;(getPlayQueue as Mock).mockResolvedValueOnce({
+      MediaContainer: {
+        Track: [
+          {
+            $: { playQueueItemID: 'pq-3', title: 'Track 3' },
+            Media: [{ Part: [{ $: { key: 'track3url.flac' } }] }]
+          },
+          {
+            $: { playQueueItemID: 'pq-4', title: 'Track 4' },
+            Media: [{ Part: [{ $: { key: 'track4url.flac' } }] }]
+          },
+          {
+            $: { playQueueItemID: 'pq-5', title: 'Track 5' },
+            Media: [{ Part: [{ $: { key: 'track5url.flac' } }] }]
+          },
+          {
+            $: { playQueueItemID: 'pq-6', title: 'Track 6' },
+            Media: [{ Part: [{ $: { key: 'track6url.flac' } }] }]
+          }
+        ]
+      }
+    })
+
+    mockPlayer.status.mockResolvedValueOnce(
+      {
+        playlist_cur_index: 2,
+        playlist_tracks: 4,
+        remoteMeta: {
+          id: 'id-3',
+          title: 'Track 3',
+          url: 'track3url.flac'
+        }
+      } // must reflect the loaded playQueue
+    )
     await handler(event)
-    expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalled()
-    // skip the first track which is currently playing (playQueueSelectedItemOffset)
-    expect(mockPlayer.addToPlaylist).toHaveBeenCalledOnce()
-    expect(mockPlayer.addToPlaylist).toHaveBeenCalledWith('http://10.10.1.1/track1', 'metadata-string')
+    // delete the first two tracks
+    //expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledTimes(2)
+    expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(0)
+    expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(1)
+    expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(3)
+    //expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(4)
+    //expect(mockPlayer.deleteTrackFromPlaylist).toHaveBeenCalledWith(5)
+    // add all the tracks after the current, now updated index which is 0 after we deleted the first two tracks to reflect refreshed queue
+    expect(mockPlayer.addToPlaylist).toHaveBeenCalledTimes(3)
+    expect(mockPlayer.addToPlaylist).toHaveBeenCalledWith('http://10.10.1.1/track1', 'metadata-string') // statically mocked input
     expect(setItemMock).toHaveBeenCalledWith('playerQueue/123', expect.anything())
     expect(h3.setResponseHeaders).toHaveBeenCalledWith(event, expect.anything())
     expect(h3.sendNoContent).toHaveBeenCalledWith(event, 200)
     expect(event.respondWith).not.toHaveBeenCalledWith(expect.any(Response))
+    expect(removeItemMock).toHaveBeenCalled()
   })
 
   it('returns 404 when player status fails', async () => {
     ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
       return mockHeaders[name]
     })
-    getItemMock.mockResolvedValue({
+    getItemMock.mockResolvedValueOnce(undefined)
+    getItemMock.mockResolvedValueOnce({
       playerId: playerInfoMock.playerid,
       playQueue: {},
       plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
@@ -156,13 +218,15 @@ describe('playback.refreshPlayQueue route', () => {
     const resp: Response = event.respondWith.mock.calls[0][0]
     expect(resp.status).toBe(404)
     expect(h3.sendNoContent).not.toHaveBeenCalled()
+    expect(removeItemMock).toHaveBeenCalled()
   })
 
   it('returns 404 when an error is thrown', async () => {
     ;(h3.getRequestHeader as Mock).mockImplementation((_e, name: string) => {
       return mockHeaders[name]
     })
-    getItemMock.mockResolvedValue({
+    getItemMock.mockResolvedValueOnce(undefined)
+    getItemMock.mockResolvedValueOnce({
       playerId: playerInfoMock.playerid,
       playQueue: {},
       plexServer: { server: { protocol: 'http', localAddress: '127.0.0.1', port: 32400 } }
@@ -173,5 +237,6 @@ describe('playback.refreshPlayQueue route', () => {
     const resp: Response = event.respondWith.mock.calls[0][0]
     expect(resp.status).toBe(404)
     expect(h3.sendNoContent).not.toHaveBeenCalled()
+    expect(removeItemMock).toHaveBeenCalled()
   })
 })

--- a/server/routes/player/playback/refreshPlayQueue.get.spec.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.spec.ts
@@ -86,9 +86,6 @@ describe('playback.refreshPlayQueue route', () => {
     vi.clearAllMocks()
     getItemMock.mockReset()
     setItemMock.mockReset()
-    // mockPlayer.status.mockResolvedValue(playerStatusMock)
-    // mockPlayer.deleteTrackFromPlaylist.mockResolvedValue(undefined)
-    // mockPlayer.addToPlaylist.mockResolvedValue(undefined)
   })
 
   it('returns 400 when required headers or playQueueID are missing', async () => {

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -62,7 +62,11 @@ export default eventHandler(async (event) => {
     if (pendingRefresh) {
       await storage.removeItem(`${lockKey}/pending`)
       logger.info(`Pending refresh detected for player '${targetClientIdentifier}', refreshing again ..`)
-      await refreshPlayQueue(playerInfo, targetClientIdentifier)
+      try {
+        await refreshPlayQueue(playerInfo, targetClientIdentifier)
+      } catch (error) {
+        logger.warn(`Error when refreshing play queue for player '${targetClientIdentifier}' during pending refresh in finally block`, error)
+      }
     }
     await storage.removeItem(lockKey)
   }

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -1,9 +1,12 @@
-import type { PlayerPlayQueue } from '../../../lib/plexPlayerTimeline'
+import type { PlayerPlayQueue, Track } from '../../../lib/plexPlayerTimeline'
 import useLogger from '../../../composables/useLogger'
 import { getRequestHeader, getQuery, eventHandler, setResponseHeaders, sendNoContent } from 'h3'
 import usePlayerInfo from '../../../composables/usePlayerInfo'
 import useSqueezePlayer from '../../../composables/useSqueezePlayer'
 import { getPlayQueue, getPlexApiTrack, metadata, responseHeaders } from '../../../lib/plexApi'
+import type { PlayerStatus } from '~~/server/lib/squeezePlayer'
+import type ExtendedSqueezePlayer from '~~/server/lib/squeezePlayer'
+import type { IPlayerInfo } from 'lms-squeeze-rpc-x/dist/modelTypes'
 
 const logger = useLogger('playback.refreshPlayQueue')
 
@@ -52,10 +55,8 @@ export default eventHandler(async (event) => {
     if (!playerQueue) {
       throw new Error(`No playerQueue available for player ${playerInfo.name} (${playerInfo.playerid}), skipping playQueue refresh ..`)
     }
-    logger.info(`Loaded playQueue has ${playerQueue.playQueue.MediaContainer.Track.length} tracks:`)
-    playerQueue.playQueue.MediaContainer.Track.forEach((track, idx) => {
-      logger.info(`Track ${idx}: ${track.$.title}`)
-    })
+    const loadedTracks = playerQueue.playQueue.MediaContainer.Track ?? []
+    logger.info(`Loaded playQueue has ${loadedTracks.length} tracks`)
 
     const refreshedPlayQueue = await getPlayQueue(playerQueue.plexServer, `/playQueues/${playQueueID}`)
     const refreshedPlayerQueue: PlayerPlayQueue = {
@@ -64,40 +65,17 @@ export default eventHandler(async (event) => {
       plexServer: playerQueue.plexServer
     }
     const refreshedTracks = refreshedPlayerQueue.playQueue.MediaContainer.Track ?? []
-    logger.info(`Refreshed playQueue has ${refreshedTracks.length} tracks:`)
-    refreshedTracks.forEach((track, idx) => {
-      logger.info(`Track ${idx}: ${track.$.title}`)
-    })
+    logger.info(`Refreshed playQueue has ${refreshedTracks.length} tracks`)
 
     const playerStatus = await player.status()
     if (!playerStatus) {
       throw new Error(`Could not get status from player '${playerInfo.name}', cannot refresh play queue`)
     }
-    const currentPlaylistIndex = playerStatus.playlist_cur_index
-    const playlistTrackCount = playerStatus.playlist_tracks
+
     const currentTrackUrl = playerStatus.remoteMeta?.url
 
     // Deleting of all the upcoming tracks is necessary if the user moved tracks around in the upcoming tracks to play in the playlist
-    logger.info(
-      `Preparing to remove ${playlistTrackCount} tracks from playlist for player '${playerInfo.name}'. Keeping track at index ${currentPlaylistIndex}...`
-    )
-    // Remove all tracks after currentPlaylistIndex
-    for (let i = playlistTrackCount - 1; i > currentPlaylistIndex; i--) {
-      await player.deleteTrackFromPlaylist(i)
-      logger.info(`Removed track at index '${i}' from playlist for player '${playerInfo.name}'`)
-    }
-    // Remove tracks before currentPlaylistIndex which are no longer in the refreshed playQueue
-    for (let i = currentPlaylistIndex - 1; i >= 0; i--) {
-      const trackKey = playerQueue.playQueue.MediaContainer.Track[i]?.Media[0]?.Part[0]?.$.key
-      logger.debug(`Checking if track at index ${i} with key '${trackKey}' still exists in refreshed playQueue`)
-      const stillExists = refreshedTracks.some((t) => t?.Media[0]?.Part[0]?.$.key === trackKey)
-      if (!stillExists) {
-        await player.deleteTrackFromPlaylist(i)
-        logger.info(
-          `Removed track at index '${i}' with key '${trackKey}' from playlist for player '${playerInfo.name}' (no longer exists in refreshed playQueue)`
-        )
-      }
-    }
+    await syncPlaylistWithRefresh(playerStatus, player, playerInfo, loadedTracks, refreshedTracks)
     const currentTrackIndex = refreshedTracks.findIndex((t) => currentTrackUrl?.includes(t?.Media[0]?.Part[0]?.$.key))
     if (currentTrackIndex === -1) {
       logger.warn(`Could not find currently loaded track in refreshedTracks by remoteMeta.url (${currentTrackUrl})`)
@@ -133,5 +111,39 @@ export default eventHandler(async (event) => {
     }
 
     logger.info(`Finished refreshing play queue for player '${targetClientIdentifier}'`)
+  }
+
+  /**
+   * Synchronizes the player's playlist with the refreshed track list on LMS.
+   */
+  async function syncPlaylistWithRefresh(
+    playerStatus: PlayerStatus,
+    player: ExtendedSqueezePlayer,
+    playerInfo: IPlayerInfo,
+    loadedTracks: Track[],
+    refreshedTracks: Track[]
+  ) {
+    const currentPlaylistIndex = playerStatus.playlist_cur_index
+    const playlistTrackCount = playerStatus.playlist_tracks
+    logger.info(
+      `Preparing to remove ${playlistTrackCount} tracks from playlist for player '${playerInfo.name}'. Keeping track at index ${currentPlaylistIndex}...`
+    )
+    // Remove all tracks after currentPlaylistIndex
+    for (let i = playlistTrackCount - 1; i > currentPlaylistIndex; i--) {
+      await player.deleteTrackFromPlaylist(i)
+      logger.info(`Removed track at index '${i}' from playlist for player '${playerInfo.name}'`)
+    }
+    // Remove tracks before currentPlaylistIndex which are no longer in the refreshed playQueue
+    for (let i = currentPlaylistIndex - 1; i >= 0; i--) {
+      const trackKey = loadedTracks[i]?.Media[0]?.Part[0]?.$.key
+      logger.debug(`Checking if track at index ${i} with key '${trackKey}' still exists in refreshed playQueue`)
+      const stillExists = refreshedTracks.some((t) => t?.Media[0]?.Part[0]?.$.key === trackKey)
+      if (!stillExists) {
+        await player.deleteTrackFromPlaylist(i)
+        logger.info(
+          `Removed track at index '${i}' with key '${trackKey}' from playlist for player '${playerInfo.name}' (no longer exists in refreshed playQueue)`
+        )
+      }
+    }
   }
 })

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -31,6 +31,19 @@ export default eventHandler(async (event) => {
     )
   }
 
+  const lockKey = `refreshPlayQueueLock/${targetClientIdentifier}`
+  // Try to acquire lock
+  const lock = await storage.getItem(lockKey)
+  if (lock) {
+    // Mark that a refresh was requested while the lock was held
+    await storage.setItem(`${lockKey}/pending`, true)
+    logger.warn(`Refresh play queue already in progress for player '${targetClientIdentifier}', skipping concurrent request.`)
+    return event.respondWith(
+      new Response(`Refresh play queue already in progress for player '${targetClientIdentifier}', try again later`, { status: 400 })
+    )
+  }
+  await storage.setItem(lockKey, Date.now())
+
   try {
     const { playerInfo } = await usePlayerInfo(targetClientIdentifier)
     const { player } = await useSqueezePlayer(targetClientIdentifier)
@@ -46,36 +59,72 @@ export default eventHandler(async (event) => {
       playQueue: refreshedPlayQueue,
       plexServer: playerQueue.plexServer
     }
+    const refreshedTracks = refreshedPlayerQueue.playQueue.MediaContainer.Track ?? []
 
     const playerStatus = await player.status()
     if (!playerStatus) {
       throw new Error(`Could not get status from player '${playerInfo.name}', cannot refresh play queue`)
     }
-    const currentPlaylistIndex = playerStatus?.playlist_cur_index
-    const playlistTrackCount = playerStatus?.playlist_tracks
+    const currentPlaylistIndex = playerStatus.playlist_cur_index
+    const playlistTrackCount = playerStatus.playlist_tracks
+    const currentTrackUrl = playerStatus.remoteMeta?.url
 
+    // Remove all tracks except the one at currentPlaylistIndex
+    // Deleting of all the upcoming tracks is necessary if the user moved tracks around in the upcoming tracks to play in the playlist
     logger.info(
-      `Cleaning up existing playQueue in player '${playerInfo.name}' from index ${currentPlaylistIndex + 1} to ${playlistTrackCount} to prepare for playQueue refresh ..`
+      `Preparing to remove ${playlistTrackCount - 1} tracks from playlist for player '${playerInfo.name}'. Keeping track at index ${currentPlaylistIndex}, removing all others.`
     )
-    for (let trackIndex = playlistTrackCount - 1; trackIndex > currentPlaylistIndex; trackIndex--) {
-      await player.deleteTrackFromPlaylist(trackIndex)
+    // Remove tracks before currentPlaylistIndex
+    for (let i = 0; i < currentPlaylistIndex; i++) {
+      const stillExists = refreshedTracks.some((t) => currentTrackUrl?.includes(t?.Media[0]?.Part[0]?.$.key))
+      if (!stillExists) {
+        await player.deleteTrackFromPlaylist(i)
+        logger.info(
+          `(before) Removed track at index '${i}' from playlist for player '${playerInfo.name}' (no longer exists in refreshed playQueue)`
+        )
+      }
     }
 
-    const selectedOffset = Number(refreshedPlayQueue.MediaContainer.$.playQueueSelectedItemOffset)
-    const tracks = refreshedPlayQueue.MediaContainer.Track.slice(selectedOffset + 1)
-    for (const track of tracks) {
+    // Remove tracks after currentPlaylistIndex
+    for (let i = playlistTrackCount - 1; i > currentPlaylistIndex; i--) {
+      await player.deleteTrackFromPlaylist(i)
+      logger.info(`(after) Removed track at index '${i}' from playlist for player '${playerInfo.name}'`)
+    }
+    const currentTrackIndex = refreshedTracks.findIndex((t) => currentTrackUrl?.includes(t?.Media[0]?.Part[0]?.$.key))
+    if (currentTrackIndex === -1) {
+      logger.warn(`Could not find currently loaded track in refreshedTracks by remoteMeta.url (${currentTrackUrl})`)
+    }
+
+    logger.info(`Current track in refreshed play queue is at index ${currentTrackIndex}`)
+    // Add all tracks in refreshedTracks that come after the current track
+    const tracksToAdd = currentTrackIndex !== -1 ? refreshedTracks.slice(currentTrackIndex + 1) : []
+
+    logger.info(`Tracks to queue from refreshed play queue after current track: ${JSON.stringify(tracksToAdd.map((t) => t.$.title))}`)
+    for (const track of tracksToAdd) {
       logger.info(`Adding track '${track.$.title}' to refreshed playQueue for player '${playerInfo.name}' ..`)
       const trackUrl = getPlexApiTrack(playerQueue.plexServer, track)
       await player.addToPlaylist(trackUrl, metadata(track))
     }
-    await storage.setItem(`playerQueue/${playerInfo.playerid}`, refreshedPlayerQueue)
 
+    await storage.setItem(`playerQueue/${playerInfo.playerid}`, refreshedPlayerQueue)
     setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))
     return sendNoContent(event, 200)
   } catch (error) {
     logger.warn(`Error when refreshing play queue for player '${targetClientIdentifier}'`, error)
     return event.respondWith(
-      new Response(`Player '${targetClientIdentifier}' play queue not available for refreshing, try again later`, { status: 404 })
+      new Response(`Player '${targetClientIdentifier}' failed to refresh play queue, try again later`, { status: 404 })
     )
+  } finally {
+    await storage.removeItem(lockKey)
+    // After releasing the lock, check if a pending refresh was requested
+    // (Place this inside the finally block, after removing the lock)
+    const pendingRefresh = await storage.getItem(`${lockKey}/pending`)
+    if (pendingRefresh) {
+      await storage.removeItem(`${lockKey}/pending`)
+      logger.info(`Pending refresh detected for player '${targetClientIdentifier}', refreshing again ..`)
+      //  eventHandler(event)
+    }
+
+    logger.info(`Finished refreshing play queue for player '${targetClientIdentifier}'`)
   }
 })

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -35,20 +35,39 @@ export default eventHandler(async (event) => {
   }
 
   const lockKey = `refreshPlayQueueLock/${targetClientIdentifier}`
-  // Try to acquire lock
+  // Try to acquire lock, this is necessary to avoid multiple concurrent refreshes for the same player if the client spams the refresh endpoint by adding many tracks quickly 
   const lock = await storage.getItem(lockKey)
   if (lock) {
     // Mark that a refresh was requested while the lock was held
     await storage.setItem(`${lockKey}/pending`, true)
     logger.warn(`Refresh play queue already in progress for player '${targetClientIdentifier}', skipping concurrent request.`)
     return event.respondWith(
-      new Response(`Refresh play queue already in progress for player '${targetClientIdentifier}', try again later`, { status: 400 })
+      new Response(`Refresh play queue already in progress for player '${targetClientIdentifier}', try again later`, { status: 404 })
     )
   }
   await storage.setItem(lockKey, Date.now())
-
+  const { playerInfo } = await usePlayerInfo(targetClientIdentifier)
   try {
-    const { playerInfo } = await usePlayerInfo(targetClientIdentifier)
+    await refreshPlayQueue(playerInfo, targetClientIdentifier)
+    setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))
+    return sendNoContent(event, 200)
+  } catch (error) {
+    logger.warn(`Error when refreshing play queue for player '${targetClientIdentifier}'`, error)
+    return event.respondWith(
+      new Response(`Player '${targetClientIdentifier}' failed to refresh play queue, try again later`, { status: 404 })
+    )
+  } finally {
+    // Check if a pending refresh was requested before releasing the lock
+    const pendingRefresh = await storage.getItem(`${lockKey}/pending`)
+    if (pendingRefresh) {
+      await storage.removeItem(`${lockKey}/pending`)
+      logger.info(`Pending refresh detected for player '${targetClientIdentifier}', refreshing again ..`)
+      await refreshPlayQueue(playerInfo, targetClientIdentifier)
+    }
+    await storage.removeItem(lockKey)
+  }
+
+  async function refreshPlayQueue(playerInfo: IPlayerInfo, targetClientIdentifier: string) {
     const { player } = await useSqueezePlayer(targetClientIdentifier)
     logger.info(`Refreshing playQueue '${playQueueID}' for player '${playerInfo.name}' ..`)
     const playerQueue = (await storage.getItem<PlayerPlayQueue>(`playerQueue/${playerInfo.playerid}`)) ?? undefined
@@ -92,25 +111,7 @@ export default eventHandler(async (event) => {
     }
 
     await storage.setItem(`playerQueue/${playerInfo.playerid}`, refreshedPlayerQueue)
-    setResponseHeaders(event, Object.fromEntries(responseHeaders(playerInfo.playerid, playerInfo.name).entries()))
-    return sendNoContent(event, 200)
-  } catch (error) {
-    logger.warn(`Error when refreshing play queue for player '${targetClientIdentifier}'`, error)
-    return event.respondWith(
-      new Response(`Player '${targetClientIdentifier}' failed to refresh play queue, try again later`, { status: 404 })
-    )
-  } finally {
-    await storage.removeItem(lockKey)
-    // After releasing the lock, check if a pending refresh was requested
-    // (Place this inside the finally block, after removing the lock)
-    const pendingRefresh = await storage.getItem(`${lockKey}/pending`)
-    if (pendingRefresh) {
-      await storage.removeItem(`${lockKey}/pending`)
-      logger.info(`Pending refresh detected for player '${targetClientIdentifier}', refreshing again ..`)
-      //  eventHandler(event)
-    }
-
-    logger.info(`Finished refreshing play queue for player '${targetClientIdentifier}'`)
+    logger.info(`Finished refreshing play queue for player '${playerInfo.name}'`)
   }
 
   /**

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -109,7 +109,7 @@ export default eventHandler(async (event) => {
     const tracksToAdd = currentTrackIndex !== -1 ? refreshedTracks.slice(currentTrackIndex + 1) : []
     logger.debug(`Tracks to queue from refreshed play queue after current track: ${JSON.stringify(tracksToAdd.map((t) => t.$.title))}`)
     for (const track of tracksToAdd) {
-      logger.info(`Adding track '${track.$.title}' to refreshed playQueue for player '${playerInfo.name}' ..`)
+      logger.debug(`Adding track '${track.$.title}' to refreshed playQueue for player '${playerInfo.name}' ..`)
       const trackUrl = getPlexApiTrack(playerQueue.plexServer, track)
       await player.addToPlaylist(trackUrl, metadata(track))
     }
@@ -136,7 +136,7 @@ export default eventHandler(async (event) => {
     // Remove all tracks after currentPlaylistIndex
     for (let i = playlistTrackCount - 1; i > currentPlaylistIndex; i--) {
       await player.deleteTrackFromPlaylist(i)
-      logger.info(`Removed track at index '${i}' from playlist for player '${playerInfo.name}'`)
+      logger.debug(`Removed track at index '${i}' from playlist for player '${playerInfo.name}'`)
     }
     // Remove tracks before currentPlaylistIndex which are no longer in the refreshed playQueue
     for (let i = currentPlaylistIndex - 1; i >= 0; i--) {
@@ -145,7 +145,7 @@ export default eventHandler(async (event) => {
       const stillExists = refreshedTracks.some((t) => t?.Media[0]?.Part[0]?.$.key === trackKey)
       if (!stillExists) {
         await player.deleteTrackFromPlaylist(i)
-        logger.info(
+        logger.debug(
           `Removed track at index '${i}' with key '${trackKey}' from playlist for player '${playerInfo.name}' (no longer exists in refreshed playQueue)`
         )
       }

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -131,7 +131,7 @@ export default eventHandler(async (event) => {
     const currentPlaylistIndex = playerStatus.playlist_cur_index
     const playlistTrackCount = playerStatus.playlist_tracks
     logger.info(
-      `Preparing to remove ${playlistTrackCount} tracks from playlist for player '${playerInfo.name}'. Keeping track at index ${currentPlaylistIndex}...`
+      `Synchronizing playlist for player '${playerInfo.name}'. Current track at index ${currentPlaylistIndex}, playlist has ${playlistTrackCount} tracks.`
     )
     // Remove all tracks after currentPlaylistIndex
     for (let i = playlistTrackCount - 1; i > currentPlaylistIndex; i--) {

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -61,7 +61,7 @@ export default eventHandler(async (event) => {
     const pendingRefresh = await storage.getItem(`${lockKey}/pending`)
     if (pendingRefresh) {
       await storage.removeItem(`${lockKey}/pending`)
-      logger.info(`Pending refresh detected for player '${targetClientIdentifier}', refreshing again ..`)
+      logger.info(`Pending refresh detected for player '${targetClientIdentifier}', refreshing again …`)
       try {
         await refreshPlayQueue(playerInfo, targetClientIdentifier)
       } catch (error) {

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -35,7 +35,7 @@ export default eventHandler(async (event) => {
   }
 
   const lockKey = `refreshPlayQueueLock/${targetClientIdentifier}`
-  // Try to acquire lock, this is necessary to avoid multiple concurrent refreshes for the same player if the client spams the refresh endpoint by adding many tracks quickly 
+  // Try to acquire lock, this is necessary to avoid multiple concurrent refreshes for the same player if the client spams the refresh endpoint by adding many tracks quickly.
   const lock = await storage.getItem(lockKey)
   if (lock) {
     // Mark that a refresh was requested while the lock was held

--- a/server/routes/player/playback/refreshPlayQueue.get.ts
+++ b/server/routes/player/playback/refreshPlayQueue.get.ts
@@ -52,6 +52,10 @@ export default eventHandler(async (event) => {
     if (!playerQueue) {
       throw new Error(`No playerQueue available for player ${playerInfo.name} (${playerInfo.playerid}), skipping playQueue refresh ..`)
     }
+    logger.info(`Loaded playQueue has ${playerQueue.playQueue.MediaContainer.Track.length} tracks:`)
+    playerQueue.playQueue.MediaContainer.Track.forEach((track, idx) => {
+      logger.info(`Track ${idx}: ${track.$.title}`)
+    })
 
     const refreshedPlayQueue = await getPlayQueue(playerQueue.plexServer, `/playQueues/${playQueueID}`)
     const refreshedPlayerQueue: PlayerPlayQueue = {
@@ -60,6 +64,10 @@ export default eventHandler(async (event) => {
       plexServer: playerQueue.plexServer
     }
     const refreshedTracks = refreshedPlayerQueue.playQueue.MediaContainer.Track ?? []
+    logger.info(`Refreshed playQueue has ${refreshedTracks.length} tracks:`)
+    refreshedTracks.forEach((track, idx) => {
+      logger.info(`Track ${idx}: ${track.$.title}`)
+    })
 
     const playerStatus = await player.status()
     if (!playerStatus) {
@@ -69,37 +77,36 @@ export default eventHandler(async (event) => {
     const playlistTrackCount = playerStatus.playlist_tracks
     const currentTrackUrl = playerStatus.remoteMeta?.url
 
-    // Remove all tracks except the one at currentPlaylistIndex
     // Deleting of all the upcoming tracks is necessary if the user moved tracks around in the upcoming tracks to play in the playlist
     logger.info(
-      `Preparing to remove ${playlistTrackCount - 1} tracks from playlist for player '${playerInfo.name}'. Keeping track at index ${currentPlaylistIndex}, removing all others.`
+      `Preparing to remove ${playlistTrackCount} tracks from playlist for player '${playerInfo.name}'. Keeping track at index ${currentPlaylistIndex}...`
     )
-    // Remove tracks before currentPlaylistIndex
-    for (let i = 0; i < currentPlaylistIndex; i++) {
-      const stillExists = refreshedTracks.some((t) => currentTrackUrl?.includes(t?.Media[0]?.Part[0]?.$.key))
+    // Remove all tracks after currentPlaylistIndex
+    for (let i = playlistTrackCount - 1; i > currentPlaylistIndex; i--) {
+      await player.deleteTrackFromPlaylist(i)
+      logger.info(`Removed track at index '${i}' from playlist for player '${playerInfo.name}'`)
+    }
+    // Remove tracks before currentPlaylistIndex which are no longer in the refreshed playQueue
+    for (let i = currentPlaylistIndex - 1; i >= 0; i--) {
+      const trackKey = playerQueue.playQueue.MediaContainer.Track[i]?.Media[0]?.Part[0]?.$.key
+      logger.debug(`Checking if track at index ${i} with key '${trackKey}' still exists in refreshed playQueue`)
+      const stillExists = refreshedTracks.some((t) => t?.Media[0]?.Part[0]?.$.key === trackKey)
       if (!stillExists) {
         await player.deleteTrackFromPlaylist(i)
         logger.info(
-          `(before) Removed track at index '${i}' from playlist for player '${playerInfo.name}' (no longer exists in refreshed playQueue)`
+          `Removed track at index '${i}' with key '${trackKey}' from playlist for player '${playerInfo.name}' (no longer exists in refreshed playQueue)`
         )
       }
-    }
-
-    // Remove tracks after currentPlaylistIndex
-    for (let i = playlistTrackCount - 1; i > currentPlaylistIndex; i--) {
-      await player.deleteTrackFromPlaylist(i)
-      logger.info(`(after) Removed track at index '${i}' from playlist for player '${playerInfo.name}'`)
     }
     const currentTrackIndex = refreshedTracks.findIndex((t) => currentTrackUrl?.includes(t?.Media[0]?.Part[0]?.$.key))
     if (currentTrackIndex === -1) {
       logger.warn(`Could not find currently loaded track in refreshedTracks by remoteMeta.url (${currentTrackUrl})`)
     }
 
-    logger.info(`Current track in refreshed play queue is at index ${currentTrackIndex}`)
+    logger.info(`Current track in refreshed play queue is at index ${currentTrackIndex}, getting all tracks after to add to playlist ..`)
     // Add all tracks in refreshedTracks that come after the current track
     const tracksToAdd = currentTrackIndex !== -1 ? refreshedTracks.slice(currentTrackIndex + 1) : []
-
-    logger.info(`Tracks to queue from refreshed play queue after current track: ${JSON.stringify(tracksToAdd.map((t) => t.$.title))}`)
+    logger.debug(`Tracks to queue from refreshed play queue after current track: ${JSON.stringify(tracksToAdd.map((t) => t.$.title))}`)
     for (const track of tracksToAdd) {
       logger.info(`Adding track '${track.$.title}' to refreshed playQueue for player '${playerInfo.name}' ..`)
       const trackUrl = getPlexApiTrack(playerQueue.plexServer, track)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,29 +5,29 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@ai-sdk/gateway@npm:1.0.34":
-  version: 1.0.34
-  resolution: "@ai-sdk/gateway@npm:1.0.34"
+"@ai-sdk/gateway@npm:2.0.5":
+  version: 2.0.5
+  resolution: "@ai-sdk/gateway@npm:2.0.5"
   dependencies:
     "@ai-sdk/provider": "npm:2.0.0"
-    "@ai-sdk/provider-utils": "npm:3.0.10"
-    "@vercel/oidc": "npm:3.0.2"
+    "@ai-sdk/provider-utils": "npm:3.0.15"
+    "@vercel/oidc": "npm:3.0.3"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/d12a3527cd84311bd8c00f82581fc6f4f576ac7631b3f5f464cbf95225159ac15a30a115041998eaccf7990a87c0ecade621bd53929cc790aad08c53e240878f
+  checksum: 10c0/95f2cf912a2a379dcee5a9ba96345e32a211a05f82eb36855d6ef8aeaa6054dc18f87166b11a3e908a028d394c6cd94684d8e0a6e1b95960cad6d77c18bb6395
   languageName: node
   linkType: hard
 
-"@ai-sdk/provider-utils@npm:3.0.10":
-  version: 3.0.10
-  resolution: "@ai-sdk/provider-utils@npm:3.0.10"
+"@ai-sdk/provider-utils@npm:3.0.15":
+  version: 3.0.15
+  resolution: "@ai-sdk/provider-utils@npm:3.0.15"
   dependencies:
     "@ai-sdk/provider": "npm:2.0.0"
     "@standard-schema/spec": "npm:^1.0.0"
-    eventsource-parser: "npm:^3.0.5"
+    eventsource-parser: "npm:^3.0.6"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/d2c16abdb84ba4ef48c9f56190b5ffde224b9e6ae5147c5c713d2623627732d34b96aa9aef2a2ea4b0c49e1b863cc963c7d7ff964a1dc95f0f036097aaaaaa98
+  checksum: 10c0/0cb233c5b61f51961d745445b0d275de3eec3c0061b82ace90af22d0fe84d986da62d18b608c3ca2e0bb2badaeb1f81d24a225f99792af84b36f954031c3a791
   languageName: node
   linkType: hard
 
@@ -40,12 +40,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/vue@npm:^2.0.59":
-  version: 2.0.61
-  resolution: "@ai-sdk/vue@npm:2.0.61"
+"@ai-sdk/vue@npm:^2.0.76":
+  version: 2.0.86
+  resolution: "@ai-sdk/vue@npm:2.0.86"
   dependencies:
-    "@ai-sdk/provider-utils": "npm:3.0.10"
-    ai: "npm:5.0.61"
+    "@ai-sdk/provider-utils": "npm:3.0.15"
+    ai: "npm:5.0.86"
     swrv: "npm:^1.0.4"
   peerDependencies:
     vue: ^3.3.4
@@ -55,7 +55,7 @@ __metadata:
       optional: true
     zod:
       optional: true
-  checksum: 10c0/1ad0bcc49e8dbbc9114e8d563cdb31e95e9edca967bf3a9b68dbf194b2deff9e48f02e32dbb38161cc11aaade24270fb4dd0d4ce7de576fc1126082d85e334a6
+  checksum: 10c0/ee568643361b5d5992b6df290a66fa1dcd683f30daa8db3681803f1366c16a342754db82f6dcfd2c9a3768e12a5e2396982f7e4f2310998509c9ca00c1afc84c
   languageName: node
   linkType: hard
 
@@ -1534,21 +1534,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@internationalized/date@npm:^3.10.0":
+  version: 3.10.0
+  resolution: "@internationalized/date@npm:3.10.0"
+  dependencies:
+    "@swc/helpers": "npm:^0.5.0"
+  checksum: 10c0/29634148f0d9232e65402a5c6a4194ecf7c375e89e687f71dd084d30315c9d544e2202de2ec26e199432c620da41a15cc473479f80897e08566e274e402f898e
+  languageName: node
+  linkType: hard
+
 "@internationalized/date@npm:^3.5.0":
   version: 3.8.2
   resolution: "@internationalized/date@npm:3.8.2"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
   checksum: 10c0/5e8dd13bf91e74109d9858752b6fdff533d510170bb0cdd8904e1d636ad31d56b6fe90805094a946b52d2035b0a3bb4a0608e3c287acd195a80b9ed041a9e4d5
-  languageName: node
-  linkType: hard
-
-"@internationalized/date@npm:^3.9.0":
-  version: 3.10.0
-  resolution: "@internationalized/date@npm:3.10.0"
-  dependencies:
-    "@swc/helpers": "npm:^0.5.0"
-  checksum: 10c0/29634148f0d9232e65402a5c6a4194ecf7c375e89e687f71dd084d30315c9d544e2202de2ec26e199432c620da41a15cc473479f80897e08566e274e402f898e
   languageName: node
   linkType: hard
 
@@ -1813,7 +1813,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@napi-rs/wasm-runtime@npm:^1.0.5, @napi-rs/wasm-runtime@npm:^1.0.6":
+"@napi-rs/wasm-runtime@npm:^1.0.6":
   version: 1.0.6
   resolution: "@napi-rs/wasm-runtime@npm:1.0.6"
   dependencies:
@@ -1821,6 +1821,17 @@ __metadata:
     "@emnapi/runtime": "npm:^1.5.0"
     "@tybys/wasm-util": "npm:^0.10.1"
   checksum: 10c0/af48168c6e13c970498fda3ce7238234a906bc69dd474dc9abd560cdf8a7dea6410147afec8f0191a1d19767c8347d8ec0125a8a93225312f7ac37e06e8c15ad
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.0.7":
+  version: 1.0.7
+  resolution: "@napi-rs/wasm-runtime@npm:1.0.7"
+  dependencies:
+    "@emnapi/core": "npm:^1.5.0"
+    "@emnapi/runtime": "npm:^1.5.0"
+    "@tybys/wasm-util": "npm:^0.10.1"
+  checksum: 10c0/2d8635498136abb49d6dbf7395b78c63422292240963bf055f307b77aeafbde57ae2c0ceaaef215601531b36d6eb92a2cdd6f5ba90ed2aa8127c27aff9c4ae55
   languageName: node
   linkType: hard
 
@@ -2104,7 +2115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/kit@npm:4.1.3, @nuxt/kit@npm:^4.0.3, @nuxt/kit@npm:^4.1.2, @nuxt/kit@npm:^4.1.3":
+"@nuxt/kit@npm:4.1.3, @nuxt/kit@npm:^4.0.3, @nuxt/kit@npm:^4.1.2":
   version: 4.1.3
   resolution: "@nuxt/kit@npm:4.1.3"
   dependencies:
@@ -2249,6 +2260,34 @@ __metadata:
     unimport: "npm:^5.2.0"
     untyped: "npm:^2.0.0"
   checksum: 10c0/0a5223c3ea836f9f3720e4ad5616c57d566633c41e6b5363078d341f52b78a4c94d1c425c413cf65759d06ec2b77b72359e16e86cba6161b3b19dca7de521084
+  languageName: node
+  linkType: hard
+
+"@nuxt/kit@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "@nuxt/kit@npm:4.2.0"
+  dependencies:
+    c12: "npm:^3.3.1"
+    consola: "npm:^3.4.2"
+    defu: "npm:^6.1.4"
+    destr: "npm:^2.0.5"
+    errx: "npm:^0.1.0"
+    exsolve: "npm:^1.0.7"
+    ignore: "npm:^7.0.5"
+    jiti: "npm:^2.6.1"
+    klona: "npm:^2.0.6"
+    mlly: "npm:^1.8.0"
+    ohash: "npm:^2.0.11"
+    pathe: "npm:^2.0.3"
+    pkg-types: "npm:^2.3.0"
+    rc9: "npm:^2.1.2"
+    scule: "npm:^1.3.0"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ufo: "npm:^1.6.1"
+    unctx: "npm:^2.4.1"
+    untyped: "npm:^2.0.0"
+  checksum: 10c0/1be5e72a52f0012ce3a29af66e7c0b23b46db36ea5a8ab679a7ee6b37b6fe827ee77b1cf00be21a20c0d989e3f460faa2f30174bec42a339198d811baa8a5b5d
   languageName: node
   linkType: hard
 
@@ -2415,13 +2454,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nuxt/ui@npm:^4.0.1":
-  version: 4.0.1
-  resolution: "@nuxt/ui@npm:4.0.1"
+"@nuxt/ui@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "@nuxt/ui@npm:4.1.0"
   dependencies:
-    "@ai-sdk/vue": "npm:^2.0.59"
+    "@ai-sdk/vue": "npm:^2.0.76"
     "@iconify/vue": "npm:^5.0.0"
-    "@internationalized/date": "npm:^3.9.0"
+    "@internationalized/date": "npm:^3.10.0"
     "@internationalized/number": "npm:^3.6.5"
     "@nuxt/fonts": "npm:^0.11.4"
     "@nuxt/icon": "npm:^2.0.0"
@@ -2429,10 +2468,11 @@ __metadata:
     "@nuxt/schema": "npm:^4.1.2"
     "@nuxtjs/color-mode": "npm:^3.5.2"
     "@standard-schema/spec": "npm:^1.0.0"
-    "@tailwindcss/postcss": "npm:^4.1.14"
-    "@tailwindcss/vite": "npm:^4.1.14"
+    "@tailwindcss/postcss": "npm:^4.1.16"
+    "@tailwindcss/vite": "npm:^4.1.16"
     "@tanstack/vue-table": "npm:^8.21.3"
-    "@unhead/vue": "npm:^2.0.17"
+    "@tanstack/vue-virtual": "npm:^3.13.12"
+    "@unhead/vue": "npm:^2.0.19"
     "@vueuse/core": "npm:^13.9.0"
     "@vueuse/integrations": "npm:^13.9.0"
     colortranslator: "npm:^5.0.0"
@@ -2450,20 +2490,20 @@ __metadata:
     knitwork: "npm:^1.2.0"
     magic-string: "npm:^0.30.19"
     mlly: "npm:^1.8.0"
-    motion-v: "npm:^1.7.2"
+    motion-v: "npm:^1.7.3"
     ohash: "npm:^2.0.11"
     pathe: "npm:^2.0.3"
-    reka-ui: "npm:2.5.1"
+    reka-ui: "npm:2.6.0"
     scule: "npm:^1.3.0"
     tailwind-merge: "npm:^3.3.1"
     tailwind-variants: "npm:^3.1.1"
-    tailwindcss: "npm:^4.1.14"
+    tailwindcss: "npm:^4.1.16"
     tinyglobby: "npm:^0.2.15"
     unplugin: "npm:^2.3.10"
     unplugin-auto-import: "npm:^20.2.0"
-    unplugin-vue-components: "npm:^29.1.0"
+    unplugin-vue-components: "npm:^30.0.0"
     vaul-vue: "npm:0.4.1"
-    vue-component-type-helpers: "npm:^3.1.0"
+    vue-component-type-helpers: "npm:^3.1.1"
   peerDependencies:
     "@inertiajs/vue3": ^2.0.7
     joi: ^18.0.0
@@ -2490,7 +2530,7 @@ __metadata:
       optional: true
   bin:
     nuxt-ui: cli/index.mjs
-  checksum: 10c0/6b400524ed04e2b1a71f6d2d63d320d97b42907f4b62f727108c528c482cb27994d12a190c4050be9e28e5a7873758df132c6113a05b2aff4b8524a0ed2e8586
+  checksum: 10c0/f2dbc863a30288c754db5583a8f5dad8385b287c43c69a5a5b04d55476a5d5b757f398185ff46608f4f17da516a1efd287e9cd7d1d90fd362eaeed979821b4ce
   languageName: node
   linkType: hard
 
@@ -3603,130 +3643,128 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tailwindcss/node@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/node@npm:4.1.14"
+"@tailwindcss/node@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/node@npm:4.1.16"
   dependencies:
     "@jridgewell/remapping": "npm:^2.3.4"
     enhanced-resolve: "npm:^5.18.3"
-    jiti: "npm:^2.6.0"
-    lightningcss: "npm:1.30.1"
+    jiti: "npm:^2.6.1"
+    lightningcss: "npm:1.30.2"
     magic-string: "npm:^0.30.19"
     source-map-js: "npm:^1.2.1"
-    tailwindcss: "npm:4.1.14"
-  checksum: 10c0/dcdb53217534b5220e8ffd0357848b542935aa5ebcae691ff1ac2924c5c0b89d6150d938ff69c776d9835e53fdb29b6db78367930985bd50b367ddb646778239
+    tailwindcss: "npm:4.1.16"
+  checksum: 10c0/ab8dcaa8328fa838cacf43656c82ea4e22fe3c44210633c86a0c4989b62ccd93338d45bdd8eb5bd096093678c73f83ebeb2ae0103cf80a1af50eddcb54cf762a
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-android-arm64@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-android-arm64@npm:4.1.14"
+"@tailwindcss/oxide-android-arm64@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-android-arm64@npm:4.1.16"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-darwin-arm64@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-darwin-arm64@npm:4.1.14"
+"@tailwindcss/oxide-darwin-arm64@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-darwin-arm64@npm:4.1.16"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-darwin-x64@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-darwin-x64@npm:4.1.14"
+"@tailwindcss/oxide-darwin-x64@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-darwin-x64@npm:4.1.16"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-freebsd-x64@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-freebsd-x64@npm:4.1.14"
+"@tailwindcss/oxide-freebsd-x64@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-freebsd-x64@npm:4.1.16"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.1.14"
+"@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-linux-arm-gnueabihf@npm:4.1.16"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-linux-arm64-gnu@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-linux-arm64-gnu@npm:4.1.14"
+"@tailwindcss/oxide-linux-arm64-gnu@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-linux-arm64-gnu@npm:4.1.16"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-linux-arm64-musl@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-linux-arm64-musl@npm:4.1.14"
+"@tailwindcss/oxide-linux-arm64-musl@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-linux-arm64-musl@npm:4.1.16"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-linux-x64-gnu@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-linux-x64-gnu@npm:4.1.14"
+"@tailwindcss/oxide-linux-x64-gnu@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-linux-x64-gnu@npm:4.1.16"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-linux-x64-musl@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-linux-x64-musl@npm:4.1.14"
+"@tailwindcss/oxide-linux-x64-musl@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-linux-x64-musl@npm:4.1.16"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-wasm32-wasi@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-wasm32-wasi@npm:4.1.14"
+"@tailwindcss/oxide-wasm32-wasi@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-wasm32-wasi@npm:4.1.16"
   dependencies:
     "@emnapi/core": "npm:^1.5.0"
     "@emnapi/runtime": "npm:^1.5.0"
     "@emnapi/wasi-threads": "npm:^1.1.0"
-    "@napi-rs/wasm-runtime": "npm:^1.0.5"
+    "@napi-rs/wasm-runtime": "npm:^1.0.7"
     "@tybys/wasm-util": "npm:^0.10.1"
     tslib: "npm:^2.4.0"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-win32-arm64-msvc@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-win32-arm64-msvc@npm:4.1.14"
+"@tailwindcss/oxide-win32-arm64-msvc@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-win32-arm64-msvc@npm:4.1.16"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide-win32-x64-msvc@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide-win32-x64-msvc@npm:4.1.14"
+"@tailwindcss/oxide-win32-x64-msvc@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide-win32-x64-msvc@npm:4.1.16"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@tailwindcss/oxide@npm:4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/oxide@npm:4.1.14"
+"@tailwindcss/oxide@npm:4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/oxide@npm:4.1.16"
   dependencies:
-    "@tailwindcss/oxide-android-arm64": "npm:4.1.14"
-    "@tailwindcss/oxide-darwin-arm64": "npm:4.1.14"
-    "@tailwindcss/oxide-darwin-x64": "npm:4.1.14"
-    "@tailwindcss/oxide-freebsd-x64": "npm:4.1.14"
-    "@tailwindcss/oxide-linux-arm-gnueabihf": "npm:4.1.14"
-    "@tailwindcss/oxide-linux-arm64-gnu": "npm:4.1.14"
-    "@tailwindcss/oxide-linux-arm64-musl": "npm:4.1.14"
-    "@tailwindcss/oxide-linux-x64-gnu": "npm:4.1.14"
-    "@tailwindcss/oxide-linux-x64-musl": "npm:4.1.14"
-    "@tailwindcss/oxide-wasm32-wasi": "npm:4.1.14"
-    "@tailwindcss/oxide-win32-arm64-msvc": "npm:4.1.14"
-    "@tailwindcss/oxide-win32-x64-msvc": "npm:4.1.14"
-    detect-libc: "npm:^2.0.4"
-    tar: "npm:^7.5.1"
+    "@tailwindcss/oxide-android-arm64": "npm:4.1.16"
+    "@tailwindcss/oxide-darwin-arm64": "npm:4.1.16"
+    "@tailwindcss/oxide-darwin-x64": "npm:4.1.16"
+    "@tailwindcss/oxide-freebsd-x64": "npm:4.1.16"
+    "@tailwindcss/oxide-linux-arm-gnueabihf": "npm:4.1.16"
+    "@tailwindcss/oxide-linux-arm64-gnu": "npm:4.1.16"
+    "@tailwindcss/oxide-linux-arm64-musl": "npm:4.1.16"
+    "@tailwindcss/oxide-linux-x64-gnu": "npm:4.1.16"
+    "@tailwindcss/oxide-linux-x64-musl": "npm:4.1.16"
+    "@tailwindcss/oxide-wasm32-wasi": "npm:4.1.16"
+    "@tailwindcss/oxide-win32-arm64-msvc": "npm:4.1.16"
+    "@tailwindcss/oxide-win32-x64-msvc": "npm:4.1.16"
   dependenciesMeta:
     "@tailwindcss/oxide-android-arm64":
       optional: true
@@ -3752,33 +3790,33 @@ __metadata:
       optional: true
     "@tailwindcss/oxide-win32-x64-msvc":
       optional: true
-  checksum: 10c0/7fdf5345272d0348624cd003f431f10715372d585f0180d32d3c8dd18f5417cdfe7e8c4e86fc504fa1aefd19324fb4c4b174bbefdc054882ae6919ed1160d86c
+  checksum: 10c0/b54912cd403f4ccfa623f7a6983d7951cc774895efbdb13811e4320a904249f091bd0b2481178c2a67d53f7aee928a08ac6a623227f4041f1bc30c9a738172af
   languageName: node
   linkType: hard
 
-"@tailwindcss/postcss@npm:^4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/postcss@npm:4.1.14"
+"@tailwindcss/postcss@npm:^4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/postcss@npm:4.1.16"
   dependencies:
     "@alloc/quick-lru": "npm:^5.2.0"
-    "@tailwindcss/node": "npm:4.1.14"
-    "@tailwindcss/oxide": "npm:4.1.14"
+    "@tailwindcss/node": "npm:4.1.16"
+    "@tailwindcss/oxide": "npm:4.1.16"
     postcss: "npm:^8.4.41"
-    tailwindcss: "npm:4.1.14"
-  checksum: 10c0/f1befe8b92ed7c162328fe359f9c118ba7edbd37e32e0d62956aed9c7891d1107c70c2dfb4dc4fae8c5acd5442529851d3762549974c973b3c4ef6c043444c03
+    tailwindcss: "npm:4.1.16"
+  checksum: 10c0/16a96cbf9234df162df5e06bcbe12256d00d36eb01158cc69818589dd614e41c324e4dcdea06523e1e25c4ee7d509b62747f032c981ed057a304473db65115ca
   languageName: node
   linkType: hard
 
-"@tailwindcss/vite@npm:^4.1.14":
-  version: 4.1.14
-  resolution: "@tailwindcss/vite@npm:4.1.14"
+"@tailwindcss/vite@npm:^4.1.16":
+  version: 4.1.16
+  resolution: "@tailwindcss/vite@npm:4.1.16"
   dependencies:
-    "@tailwindcss/node": "npm:4.1.14"
-    "@tailwindcss/oxide": "npm:4.1.14"
-    tailwindcss: "npm:4.1.14"
+    "@tailwindcss/node": "npm:4.1.16"
+    "@tailwindcss/oxide": "npm:4.1.16"
+    tailwindcss: "npm:4.1.16"
   peerDependencies:
     vite: ^5.2.0 || ^6 || ^7
-  checksum: 10c0/38a34602a29fcad23eb80bdb6f3162473d191a1d8ec0bffdee73a1c7b9716de13a1c3705b95baf40eed6ed70e806df35ba03f3cfe541f1758a3440ddb03b6e81
+  checksum: 10c0/3d0c1896ef9b5455e118e4d5ee93d45a28501b1fe0ed8136c40657c591914557a83a5a79129d5c894a52791a1c86ab39edbd8cfc87de853749869b670a888a16
   languageName: node
   linkType: hard
 
@@ -3793,6 +3831,13 @@ __metadata:
   version: 3.13.10
   resolution: "@tanstack/virtual-core@npm:3.13.10"
   checksum: 10c0/ecfe56cc37db088416abb1f1b9641cc7b05b387bb532e4fe42f30a5477e55fdbb724f54e8dc5c3d8b380a5e9f80cc11426519825f8ecbcb6ca717639ba702cc8
+  languageName: node
+  linkType: hard
+
+"@tanstack/virtual-core@npm:3.13.12":
+  version: 3.13.12
+  resolution: "@tanstack/virtual-core@npm:3.13.12"
+  checksum: 10c0/483f38761b73db05c181c10181f0781c1051be3350ae5c378e65057e5f1fdd6606e06e17dbaad8a5e36c04b208ea1a1344cacd4eca0dcde60f335cf398e4d698
   languageName: node
   linkType: hard
 
@@ -3815,6 +3860,17 @@ __metadata:
   peerDependencies:
     vue: ^2.7.0 || ^3.0.0
   checksum: 10c0/741f4b2b3ab77363511cfa2ff57fc075f75f2561a15d3826fcc88b6863b529f51769bb9fce90fb793339f443a63e8980a416425a70abeacb516863b2bbb8c7ed
+  languageName: node
+  linkType: hard
+
+"@tanstack/vue-virtual@npm:^3.13.12":
+  version: 3.13.12
+  resolution: "@tanstack/vue-virtual@npm:3.13.12"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.13.12"
+  peerDependencies:
+    vue: ^2.7.0 || ^3.0.0
+  checksum: 10c0/fd4ce83567f861e1a7d152c62ffdc2be287c3f57dedc3d64d390132fa8fe4ee29ee4341fc46d6b69fb3938a5bb0e39e6d181ebb6a4b216c667a90b57bfe443a3
   languageName: node
   linkType: hard
 
@@ -4530,7 +4586,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unhead/vue@npm:^2.0.17":
+"@unhead/vue@npm:^2.0.19":
   version: 2.0.19
   resolution: "@unhead/vue@npm:2.0.19"
   dependencies:
@@ -4699,10 +4755,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/oidc@npm:3.0.2":
-  version: 3.0.2
-  resolution: "@vercel/oidc@npm:3.0.2"
-  checksum: 10c0/8d4c8553baa5aed339ab7614d775139bc124a6d443b76877ab17e98c156daa4dbeb3cf2f3bf21fabfae2ac0dd3ff462ab43b9398708e02483e5923d302a1c4c8
+"@vercel/oidc@npm:3.0.3":
+  version: 3.0.3
+  resolution: "@vercel/oidc@npm:3.0.3"
+  checksum: 10c0/c8eecb1324559435f4ab8a955f5ef44f74f546d11c2ddcf28151cb636d989bd4b34e0673fd8716cb21bb21afb34b3de663bacc30c9506036eeecbcbf2fd86241
   languageName: node
   linkType: hard
 
@@ -5674,17 +5730,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ai@npm:5.0.61":
-  version: 5.0.61
-  resolution: "ai@npm:5.0.61"
+"ai@npm:5.0.86":
+  version: 5.0.86
+  resolution: "ai@npm:5.0.86"
   dependencies:
-    "@ai-sdk/gateway": "npm:1.0.34"
+    "@ai-sdk/gateway": "npm:2.0.5"
     "@ai-sdk/provider": "npm:2.0.0"
-    "@ai-sdk/provider-utils": "npm:3.0.10"
+    "@ai-sdk/provider-utils": "npm:3.0.15"
     "@opentelemetry/api": "npm:1.9.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/2ae59076f32519fdd7f042c398dd9f0ea4277b5729ab9eb3f4ede0bc4ba69a466d8183da44d99889254526f27bbb6c77ed5fcb3e786f1f0be41502b3db5c3eff
+  checksum: 10c0/f57f9c79df28acd3b2d4565048caa79945a53ee4f3060865ec3692623cae0e94ef66c0d8b137a290f447ee4d6c62aae1b800ce57434b91d1781bf1cdb09ffa1f
   languageName: node
   linkType: hard
 
@@ -6245,6 +6301,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"c12@npm:^3.3.1":
+  version: 3.3.1
+  resolution: "c12@npm:3.3.1"
+  dependencies:
+    chokidar: "npm:^4.0.3"
+    confbox: "npm:^0.2.2"
+    defu: "npm:^6.1.4"
+    dotenv: "npm:^17.2.3"
+    exsolve: "npm:^1.0.7"
+    giget: "npm:^2.0.0"
+    jiti: "npm:^2.6.1"
+    ohash: "npm:^2.0.11"
+    pathe: "npm:^2.0.3"
+    perfect-debounce: "npm:^2.0.0"
+    pkg-types: "npm:^2.3.0"
+    rc9: "npm:^2.1.2"
+  peerDependencies:
+    magicast: ^0.3.5
+  peerDependenciesMeta:
+    magicast:
+      optional: true
+  checksum: 10c0/37b70f838980eba3836ec9754b2c28e28d4eda272baefb1e22ff997ee7569a5f2a50acd41d65ea645969cbd66e5a8334f8634b2c264a8abd0af3caeee75e6351
+  languageName: node
+  linkType: hard
+
 "cac@npm:^6.7.14":
   version: 6.7.14
   resolution: "cac@npm:6.7.14"
@@ -6381,7 +6462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chokidar@npm:^3.4.2, chokidar@npm:^3.6.0":
+"chokidar@npm:^3.4.2":
   version: 3.6.0
   resolution: "chokidar@npm:3.6.0"
   dependencies:
@@ -7197,7 +7278,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-libc@npm:^2.0.3, detect-libc@npm:^2.0.4":
+"detect-libc@npm:^2.0.3":
   version: 2.0.4
   resolution: "detect-libc@npm:2.0.4"
   checksum: 10c0/c15541f836eba4b1f521e4eecc28eefefdbc10a94d3b8cb4c507689f332cc111babb95deda66f2de050b22122113189986d5190be97d51b5a2b23b938415e67c
@@ -7293,7 +7374,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dotenv@npm:^17.2.2":
+"dotenv@npm:^17.2.2, dotenv@npm:^17.2.3":
   version: 17.2.3
   resolution: "dotenv@npm:17.2.3"
   checksum: 10c0/c884403209f713214a1b64d4d1defa4934c2aa5b0002f5a670ae298a51e3c3ad3ba79dfee2f8df49f01ae74290fcd9acdb1ab1d09c7bfb42b539036108bb2ba0
@@ -8360,7 +8441,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventsource-parser@npm:^3.0.5":
+"eventsource-parser@npm:^3.0.6":
   version: 3.0.6
   resolution: "eventsource-parser@npm:3.0.6"
   checksum: 10c0/70b8ccec7dac767ef2eca43f355e0979e70415701691382a042a2df8d6a68da6c2fca35363669821f3da876d29c02abe9b232964637c1b6635c940df05ada78a
@@ -10091,7 +10172,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jiti@npm:^2.6.0, jiti@npm:^2.6.1":
+"jiti@npm:^2.6.1":
   version: 2.6.1
   resolution: "jiti@npm:2.6.1"
   bin:
@@ -10332,92 +10413,102 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lightningcss-darwin-arm64@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-darwin-arm64@npm:1.30.1"
+"lightningcss-android-arm64@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-android-arm64@npm:1.30.2"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-darwin-arm64@npm:1.30.2"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"lightningcss-darwin-x64@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-darwin-x64@npm:1.30.1"
+"lightningcss-darwin-x64@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-darwin-x64@npm:1.30.2"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss-freebsd-x64@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-freebsd-x64@npm:1.30.1"
+"lightningcss-freebsd-x64@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-freebsd-x64@npm:1.30.2"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm-gnueabihf@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.30.1"
+"lightningcss-linux-arm-gnueabihf@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.30.2"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm64-gnu@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-linux-arm64-gnu@npm:1.30.1"
+"lightningcss-linux-arm64-gnu@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.30.2"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"lightningcss-linux-arm64-musl@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-linux-arm64-musl@npm:1.30.1"
+"lightningcss-linux-arm64-musl@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-linux-arm64-musl@npm:1.30.2"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"lightningcss-linux-x64-gnu@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-linux-x64-gnu@npm:1.30.1"
+"lightningcss-linux-x64-gnu@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-linux-x64-gnu@npm:1.30.2"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"lightningcss-linux-x64-musl@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-linux-x64-musl@npm:1.30.1"
+"lightningcss-linux-x64-musl@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-linux-x64-musl@npm:1.30.2"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"lightningcss-win32-arm64-msvc@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-win32-arm64-msvc@npm:1.30.1"
+"lightningcss-win32-arm64-msvc@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.30.2"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"lightningcss-win32-x64-msvc@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss-win32-x64-msvc@npm:1.30.1"
+"lightningcss-win32-x64-msvc@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss-win32-x64-msvc@npm:1.30.2"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"lightningcss@npm:1.30.1":
-  version: 1.30.1
-  resolution: "lightningcss@npm:1.30.1"
+"lightningcss@npm:1.30.2":
+  version: 1.30.2
+  resolution: "lightningcss@npm:1.30.2"
   dependencies:
     detect-libc: "npm:^2.0.3"
-    lightningcss-darwin-arm64: "npm:1.30.1"
-    lightningcss-darwin-x64: "npm:1.30.1"
-    lightningcss-freebsd-x64: "npm:1.30.1"
-    lightningcss-linux-arm-gnueabihf: "npm:1.30.1"
-    lightningcss-linux-arm64-gnu: "npm:1.30.1"
-    lightningcss-linux-arm64-musl: "npm:1.30.1"
-    lightningcss-linux-x64-gnu: "npm:1.30.1"
-    lightningcss-linux-x64-musl: "npm:1.30.1"
-    lightningcss-win32-arm64-msvc: "npm:1.30.1"
-    lightningcss-win32-x64-msvc: "npm:1.30.1"
+    lightningcss-android-arm64: "npm:1.30.2"
+    lightningcss-darwin-arm64: "npm:1.30.2"
+    lightningcss-darwin-x64: "npm:1.30.2"
+    lightningcss-freebsd-x64: "npm:1.30.2"
+    lightningcss-linux-arm-gnueabihf: "npm:1.30.2"
+    lightningcss-linux-arm64-gnu: "npm:1.30.2"
+    lightningcss-linux-arm64-musl: "npm:1.30.2"
+    lightningcss-linux-x64-gnu: "npm:1.30.2"
+    lightningcss-linux-x64-musl: "npm:1.30.2"
+    lightningcss-win32-arm64-msvc: "npm:1.30.2"
+    lightningcss-win32-x64-msvc: "npm:1.30.2"
   dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
     lightningcss-darwin-arm64:
       optional: true
     lightningcss-darwin-x64:
@@ -10438,7 +10529,7 @@ __metadata:
       optional: true
     lightningcss-win32-x64-msvc:
       optional: true
-  checksum: 10c0/1e1ad908f3c68bf39d964a6735435a8dd5474fb2765076732d64a7b6aa2af1f084da65a9462443a9adfebf7dcfb02fb532fce1d78697f2a9de29c8f40f09aee3
+  checksum: 10c0/5c0c73a33946dab65908d5cd1325df4efa290efb77f940b60f40448b5ab9a87d3ea665ef9bcf00df4209705050ecf2f7ecc649f44d6dfa5905bb50f15717e78d
   languageName: node
   linkType: hard
 
@@ -10976,15 +11067,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minizlib@npm:^3.1.0":
-  version: 3.1.0
-  resolution: "minizlib@npm:3.1.0"
-  dependencies:
-    minipass: "npm:^7.1.2"
-  checksum: 10c0/5aad75ab0090b8266069c9aabe582c021ae53eb33c6c691054a13a45db3b4f91a7fb1bd79151e6b4e9e9a86727b522527c0a06ec7d45206b745d54cd3097bcec
-  languageName: node
-  linkType: hard
-
 "mitt@npm:^3.0.1":
   version: 3.0.1
   resolution: "mitt@npm:3.0.1"
@@ -11066,9 +11148,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"motion-v@npm:^1.7.2":
-  version: 1.7.2
-  resolution: "motion-v@npm:1.7.2"
+"motion-v@npm:^1.7.3":
+  version: 1.7.4
+  resolution: "motion-v@npm:1.7.4"
   dependencies:
     framer-motion: "npm:12.23.12"
     hey-listen: "npm:^1.0.8"
@@ -11076,7 +11158,7 @@ __metadata:
   peerDependencies:
     "@vueuse/core": ">=10.0.0"
     vue: ">=3.0.0"
-  checksum: 10c0/005cff670dae5d08e72577c802f56bb12ae0f62b6a08668e4c99315ae47ba084aedeaf99f7b34736751f1547372ee8c50044da71536615deac6f1ee766a936c9
+  checksum: 10c0/6b3ddcd9878d748cd4eef89d07ff0fc9b1e3106dd4df72d1b7b4f19c6428c9f1fb336ed0182be93789db9ffb2f7d8004b5b51dac911fcbd78d376a3ca94c535c
   languageName: node
   linkType: hard
 
@@ -12873,9 +12955,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reka-ui@npm:2.5.1":
-  version: 2.5.1
-  resolution: "reka-ui@npm:2.5.1"
+"reka-ui@npm:2.6.0":
+  version: 2.6.0
+  resolution: "reka-ui@npm:2.6.0"
   dependencies:
     "@floating-ui/dom": "npm:^1.6.13"
     "@floating-ui/vue": "npm:^1.1.6"
@@ -12889,7 +12971,7 @@ __metadata:
     ohash: "npm:^2.0.11"
   peerDependencies:
     vue: ">= 3.2.0"
-  checksum: 10c0/085f3d58d5044a24a4d182e9e4d6f873371d01639bc03598133686211f278b86e5b0a66b4ffae0f6b4002a7c477dcf2af1048cea45c6751dc42c1712cc6c02f3
+  checksum: 10c0/40a3492b6bc424c2fd6875d969353df9c41deaf5f0f77cb0d4c02c12076a9057b75a23a2842a0b45ab8fb1e0a11c8d37ad6f85e7313c9d8a6664610fb834f5d0
   languageName: node
   linkType: hard
 
@@ -13314,6 +13396,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.3":
+  version: 7.7.3
+  resolution: "semver@npm:7.7.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
+  languageName: node
+  linkType: hard
+
 "send@npm:^1.2.0":
   version: 1.2.0
   resolution: "send@npm:1.2.0"
@@ -13660,11 +13751,11 @@ __metadata:
   resolution: "squeeze-plex-hub@workspace:."
   dependencies:
     "@nuxt/eslint-config": "npm:^1.9.0"
-    "@nuxt/kit": "npm:^4.1.3"
+    "@nuxt/kit": "npm:^4.2.0"
     "@nuxt/test-utils": "npm:^3.19.2"
     "@nuxt/types": "npm:^2.18.1"
     "@nuxt/typescript-build": "npm:^3.0.2"
-    "@nuxt/ui": "npm:^4.0.1"
+    "@nuxt/ui": "npm:^4.1.0"
     "@types/jest": "npm:^30.0.0"
     "@types/xml2js": "npm:^0.4.14"
     "@typescript-eslint/eslint-plugin": "npm:^8.39.1"
@@ -14045,10 +14136,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tailwindcss@npm:4.1.14, tailwindcss@npm:^4.1.14":
-  version: 4.1.14
-  resolution: "tailwindcss@npm:4.1.14"
-  checksum: 10c0/c7e9ebfb241707b2a3eb7d465fd326cc8fcfa22e7215e01f67cccec32db8a49a19e17d1f694fc5d0435d55350ea3f863521c52c9bbe6bd790c2009dc8ff516a1
+"tailwindcss@npm:4.1.16, tailwindcss@npm:^4.1.16":
+  version: 4.1.16
+  resolution: "tailwindcss@npm:4.1.16"
+  checksum: 10c0/11beec3112686767292f43d602ffa26068be6b505adba7929ad17b2a3d8e262bdb2eb7c8d226325654ab8268ddd0ca7b7231df8ba59a77becbdae0df9f86268a
   languageName: node
   linkType: hard
 
@@ -14102,19 +14193,6 @@ __metadata:
     mkdirp: "npm:^3.0.1"
     yallist: "npm:^5.0.0"
   checksum: 10c0/d4679609bb2a9b48eeaf84632b6d844128d2412b95b6de07d53d8ee8baf4ca0857c9331dfa510390a0727b550fd543d4d1a10995ad86cdf078423fbb8d99831d
-  languageName: node
-  linkType: hard
-
-"tar@npm:^7.5.1":
-  version: 7.5.1
-  resolution: "tar@npm:7.5.1"
-  dependencies:
-    "@isaacs/fs-minipass": "npm:^4.0.0"
-    chownr: "npm:^3.0.0"
-    minipass: "npm:^7.1.2"
-    minizlib: "npm:^3.1.0"
-    yallist: "npm:^5.0.0"
-  checksum: 10c0/0dad0596a61586180981133b20c32cfd93c5863c5b7140d646714e6ea8ec84583b879e5dc3928a4d683be6e6109ad7ea3de1cf71986d5194f81b3a016c8858c9
   languageName: node
   linkType: hard
 
@@ -14693,18 +14771,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"unplugin-vue-components@npm:^29.1.0":
-  version: 29.1.0
-  resolution: "unplugin-vue-components@npm:29.1.0"
+"unplugin-vue-components@npm:^30.0.0":
+  version: 30.0.0
+  resolution: "unplugin-vue-components@npm:30.0.0"
   dependencies:
-    chokidar: "npm:^3.6.0"
+    chokidar: "npm:^4.0.3"
     debug: "npm:^4.4.3"
     local-pkg: "npm:^1.1.2"
     magic-string: "npm:^0.30.19"
     mlly: "npm:^1.8.0"
     tinyglobby: "npm:^0.2.15"
     unplugin: "npm:^2.3.10"
-    unplugin-utils: "npm:^0.3.0"
+    unplugin-utils: "npm:^0.3.1"
   peerDependencies:
     "@babel/parser": ^7.15.8
     "@nuxt/kit": ^3.2.2 || ^4.0.0
@@ -14714,7 +14792,7 @@ __metadata:
       optional: true
     "@nuxt/kit":
       optional: true
-  checksum: 10c0/fbc1ae4f45d98bc2b135237f40a0014d5a08179e561a464604f5dc04e595b7b00037ec18c6809aaae94fe6b30067bcda405d6a2802a955bbd2340c82713ee1d8
+  checksum: 10c0/8d6699669e53f71a2c380d81a704270f4675cf30e3c4ad383171f29e8a25de76d5128dab613df1e0c28b38b083f42bda9a287c282b3722540b5b6eb50578232f
   languageName: node
   linkType: hard
 
@@ -15404,10 +15482,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vue-component-type-helpers@npm:^3.1.0":
-  version: 3.1.1
-  resolution: "vue-component-type-helpers@npm:3.1.1"
-  checksum: 10c0/f5d503efa70add1006bd90af38f43f6552dd356bb1b28782c7a6c708638c2ef9378d644c906ead161ca1c549af1b27e01805f9dc3ff8c323318b5bf5a24219c9
+"vue-component-type-helpers@npm:^3.1.1":
+  version: 3.1.2
+  resolution: "vue-component-type-helpers@npm:3.1.2"
+  checksum: 10c0/c29473e2907cf665634e76cb6cc6403eff10b96cef0cab7381c8b42b6d75bd6bafad49e75f0d47f7b8eec39024d330b5e3e6211b9ecd92aea2f4dad3d3e6dd2b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request refactors the play queue refresh logic for the player routes, introducing a locking mechanism to prevent concurrent refreshes, improving playlist synchronization with the refreshed queue, and updating related tests for more accurate and robust coverage. The changes ensure that the playlist state on the player is consistent with the Plex play queue, even when tracks are added, removed, or reordered, and prevent race conditions when multiple refresh requests occur.

### Play Queue Refresh Logic Improvements

* Added a locking mechanism using storage keys to prevent concurrent refreshes for the same player, with support for pending refresh requests and automatic retry after the lock is released.
* Refactored the refresh logic into a dedicated `refreshPlayQueue` function, and introduced a helper `syncPlaylistWithRefresh` to accurately remove and add tracks so the player's playlist matches the refreshed Plex play queue.

### Playlist Synchronization

* Improved logic to remove tracks both after and before the current track index if they no longer exist in the refreshed play queue, ensuring the playlist on the player is always up-to-date.

