### PR TITLE
improve polling wait=1 logic

### DIFF
--- a/server/lib/plexPlayerTimeline.ts
+++ b/server/lib/plexPlayerTimeline.ts
@@ -244,8 +244,8 @@ const timelineContainer = (
           },
           ...(includeMetadata && currentTrack ? { Track: currentTrack } : {}) // THIS IS ESSENTIAL since Plexamp struggles with </Track> tag if no playQueue is loaded
         },
-        createEmptyTimeline('video', playerStatus),
-        createEmptyTimeline('photo', playerStatus)
+        createEmptyTimeline('video'),
+        createEmptyTimeline('photo')
       ]
     }
   }
@@ -292,14 +292,14 @@ const timelineContainer = (
     return playerStatus.volume < 0 ? '1' : '0'
   }
 
-  function createEmptyTimeline(type: string, playerStatus: PlayerStatus): Timeline {
+  function createEmptyTimeline(type: string): Timeline {
     return {
       $: {
         type,
         itemType: type,
         state: 'stopped',
-        time: Math.round(playerStatus.time * 1000).toString(), // the current time of the track playing in ms
-        volume: volume(),
+        time: '0',
+        volume: '0',
         controllable: plexOptions.controllable
       }
     }

--- a/server/lib/squeezePlexHub.ts
+++ b/server/lib/squeezePlexHub.ts
@@ -1,11 +1,13 @@
+const { appVersion } = useRuntimeConfig()
+
 export const plexOptions = {
   identifier: 'SqueezePlexHub',
   product: 'Squeeze Plex Hub', // Plexamp, Plex Web,
-  version: '1.0',
-  device: 'Windows', // $device:$model combination found to be accepted by controller = Windows:$ANYSTRING, Android:$ANYSTRING iOS:$ANYSTRING
+  version: appVersion,
+  device: 'Windows', // $device:$model combination found to be accepted by :/timeline endpoint = Windows:$ANYSTRING, Android:$ANYSTRING iOS:$ANYSTRING
   model: 'Squeezebox Player',
   platform: 'Squeeze Plex Hub', // Linux, Safari
-  platformVersion: '1.0',
+  platformVersion: appVersion,
   deviceClass: 'speaker', // will result in a speaker icon on mobile (also possible values: stb, tablet, mobile, pc)
   protocol: 'plex',
   protocolVersion: '1',

--- a/server/plugins/timelinePublisher.ts
+++ b/server/plugins/timelinePublisher.ts
@@ -86,11 +86,11 @@ export async function runPublishTimeline() {
 
         const serverTimelineUrl = `http://${playerQueue.plexServer.server.localAddress}:${playerQueue.plexServer.server.port}/:/timeline`
         for (const subscriber of playerSubscribers || []) {
-          const timeline = await timelineResponse(playerStatus, subscriber, playerQueue, true)
+          const timeline = await timelineResponse(playerStatus, subscriber, playerQueue, false)
           const timelineString = builder.buildObject(timeline)
           await Promise.all(
             timeline.MediaContainer.Timeline.map(async (timelineItem) => {
-              logger.debug(`Sending timeline '${timelineItem.$.itemType}' to subscriber '${subscriber.deviceName}' ..`)
+              logger.debug(`Trying to send timeline '${timelineItem.$.itemType}' to subscriber '${subscriber.deviceName}' ..`)
 
               if (
                 !timelineItem.$.state ||

--- a/server/routes/player/timeline/poll.get.spec.ts
+++ b/server/routes/player/timeline/poll.get.spec.ts
@@ -150,6 +150,58 @@ describe('timeline.poll handler', () => {
     )
   })
 
+  it('responds with timeline xml for wait poll without loaded player playQueue', async () => {
+    // Simulate playQueue currently not updating for player
+    mockGetItem.mockResolvedValueOnce(false)
+    const respondWith = vi.fn()
+    const event = createEvent({
+      headers: {
+        'X-Plex-Target-Client-Identifier': 'abc123',
+        'X-Plex-Client-Identifier': 'client1',
+        'X-Plex-Device-Name': 'dev1'
+      },
+      query: { commandID: 'cmd1', wait: '1' },
+      respondWith
+    })
+
+    ;(timelineResponse as Mock).mockResolvedValue(mockTimelineXml)
+
+    mockPlayer.status.mockResolvedValue({
+      playerId: 'abc123',
+      mode: 'play',
+      time: 50,
+      playlist_cur_index: 3,
+      playlist_tracks: 5,
+      duration: 100,
+      volume: 50,
+      remoteMeta: { url: 'http://pms.local/track3url.flac' }
+    })
+    const subscriber = {
+        clientIdentifier: 'client1',
+        deviceName: 'dev1',
+        commandId: 'cmd1',
+        poll: true,
+        targetClientIdentifier: 'abc123',
+        subscribedAt: expect.any(Date)
+      }
+
+    await pollHandler(event)
+    expect(mockSetItem).toHaveBeenCalledWith('subscribers/abc123/client1', subscriber)
+    expect(timelineResponse).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining(subscriber),
+      undefined,
+      false,
+      false
+    )
+    expect(timelineResponse).toHaveBeenCalledTimes(1)
+    expect(respondWith).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 200
+      })
+    )
+  })
+
   it('responds with timeline xml for non wait poll without loaded player playQueue', async () => {
     // Simulate playQueue currently updating for player
     mockGetItem.mockResolvedValueOnce(true)

--- a/server/routes/player/timeline/poll.get.ts
+++ b/server/routes/player/timeline/poll.get.ts
@@ -119,7 +119,7 @@ export default eventHandler(async (event) => {
     if (queryParameters.wait === '1') {
       // don't send timeline response immediately, wait for player to change state and send timeline response in timelinePublisher
       await storage.setItem(`subscribers/${targetClientIdentifier}/${clientIdentifier}`, subscriber)
-      logger.info(`Client '${clientIdentifier}' subscribed to player '${playerInfo.name}' for polling`)
+      logger.info(`Client '${clientIdentifier}' subscribed to player '${playerInfo.name}' for polling (wait = 1)`)
       // TODO don't really understand the wait === 1 logic, this works as a workaround for now to prevent the client going wild with subscribing
       await new Promise((resolve) => setTimeout(resolve, 5000))
       const status = await player.status()

--- a/server/routes/player/timeline/poll.get.ts
+++ b/server/routes/player/timeline/poll.get.ts
@@ -121,7 +121,7 @@ export default eventHandler(async (event) => {
       await storage.setItem(`subscribers/${targetClientIdentifier}/${clientIdentifier}`, subscriber)
       logger.info(`Client '${clientIdentifier}' subscribed to player '${playerInfo.name}' for polling (wait = 1)`)
       // TODO don't really understand the wait === 1 logic, this works as a workaround for now to prevent the client going wild with subscribing
-      await new Promise((resolve) => setTimeout(resolve, 5000))
+      await new Promise((resolve) => setTimeout(resolve, 1000))
       const status = await player.status()
       if (status) {
         const timelineXml = await timelineResponse(status, subscriber, playerQueue, queryParameters.includeMetadata, playerQueueUpdating)

--- a/server/routes/resources.get.spec.ts
+++ b/server/routes/resources.get.spec.ts
@@ -22,20 +22,6 @@ vi.mock('../composables/useLogger', () => ({
 vi.mock('../composables/usePlayerInfo', () => ({
   default: vi.fn()
 }))
-vi.mock('../lib/squeezePlexHub', () => ({
-  plexOptions: {
-    platform: 'MockPlatform',
-    platformVersion: '1.0',
-    product: 'MockProduct',
-    version: '1.0',
-    protocol: 'MockProtocol',
-    protocolVersion: '1',
-    model: 'MockModel',
-    device: 'MockDevice',
-    protocolCapabilities: 'MockCapabilities',
-    deviceClass: 'MockClass'
-  }
-}))
 
 vi.mock('h3', async () => {
   const actual = await vi.importActual<typeof import('h3')>('h3')

--- a/setup-nitro-test-env.ts
+++ b/setup-nitro-test-env.ts
@@ -5,5 +5,7 @@ import { defineNitroPlugin as _defineNitroPlugin } from 'nitropack/runtime/inter
 
 // Define a dummy defineTask to avoid ReferenceError in tests
 ;(globalThis as any).defineTask = (task: any) => task
-
-
+// Define a dummy useRuntimeConfig for tests
+;(globalThis as any).useRuntimeConfig = () => ({
+  appVersion: '1.2.3-test'
+})


### PR DESCRIPTION
it seems like plex web client is no longer working with Plexamp remote players. One can start, stop seek the track but the response from remote player /poll?wait=1 endpoints seems ignored. Obviously, it behaves the same for Squeeze Plex Hub. 

<img width="1084" height="249" alt="Screenshot 2025-11-06 at 22 04 32" src="https://github.com/user-attachments/assets/dabb5464-719a-4bb1-8a6f-928ee3f39baa" />

Furthermore, plex web client can only discover a single Squeezebox player, here it also behaves the same with Plexamp remote players. 
<img width="271" height="134" alt="Screenshot 2025-11-06 at 22 29 28" src="https://github.com/user-attachments/assets/ace63d68-759f-42a4-a979-2ff7c6df6e81" />

Therefore, will park this until Plex has fixed this.