### PR TITLE
#73 lms squeeze plex hub plugin support

### DIFF
--- a/server/lib/plexApi.spec.ts
+++ b/server/lib/plexApi.spec.ts
@@ -3,7 +3,6 @@ import { parseStringPromise } from 'xml2js'
 import * as plexApi from './plexApi'
 import type { Track } from './plexPlayerTimeline'
 import { describe, expect, it, vi, type Mock } from 'vitest'
-import { r } from 'happy-dom/lib/PropertySymbol'
 
 vi.mock('axios')
 vi.mock('xml2js', () => ({

--- a/server/lib/plexApi.spec.ts
+++ b/server/lib/plexApi.spec.ts
@@ -3,6 +3,7 @@ import { parseStringPromise } from 'xml2js'
 import * as plexApi from './plexApi'
 import type { Track } from './plexPlayerTimeline'
 import { describe, expect, it, vi, type Mock } from 'vitest'
+import { r } from 'happy-dom/lib/PropertySymbol'
 
 vi.mock('axios')
 vi.mock('xml2js', () => ({
@@ -30,7 +31,8 @@ const mockTrack: Track = {
   $: {
     grandparentTitle: 'Artist',
     parentTitle: 'Album',
-    title: 'Song'
+    title: 'Song',
+    ratingKey: '66666'
   },
   Media: [
     {
@@ -63,7 +65,7 @@ describe('plexApi', () => {
   describe('getPlexApiTrack', () => {
     it('should build the correct track URL', () => {
       const url = plexApi.getPlexApiTrack(mockPlexServer, mockTrack)
-      expect(url).toBe('http://127.0.0.1:32400/library/parts/1/file.mp3?X-Plex-Token=token123')
+      expect(url).toBe('http://127.0.0.1:32400/library/parts/1/file.mp3?X-Plex-Token=token123&squeezePlexHub_rk=66666')
     })
   })
 

--- a/server/lib/plexApi.ts
+++ b/server/lib/plexApi.ts
@@ -45,7 +45,7 @@ export function getPlexApi(plexServer: PlexServer, path: string): string {
  * @returns Plex API URL for the given track to stream it
  */
 export function getPlexApiTrack(plexServer: PlexServer, track: Track): string {
-  return `${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}${track?.Media[0]?.Part[0]?.$.key}?X-Plex-Token=${plexServer.token}&squeezePlexHub_rk=${track.$.ratingKey}`  
+  return `${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}${track?.Media[0]?.Part[0]?.$.key}?X-Plex-Token=${plexServer.token}&squeezePlexHub_rk=${track?.$.ratingKey}`  
 }
 
 /**

--- a/server/lib/plexApi.ts
+++ b/server/lib/plexApi.ts
@@ -45,8 +45,7 @@ export function getPlexApi(plexServer: PlexServer, path: string): string {
  * @returns Plex API URL for the given track to stream it
  */
 export function getPlexApiTrack(plexServer: PlexServer, track: Track): string {
-  return `${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}${track?.Media[0]?.Part[0]?.$.key}?X-Plex-Token=${plexServer.token}`
-  //TODO return `${protocol}://${address}:${port}${track.file}?X-Plex-Token=${token}&artist=mytitle&title=blubber&cover=https%3A%2F%2Fwww.rockarchive.com%2Fmedia%2F1890%2Fdavid-bowie-db001duffy.jpg%3Fcrop%3D0.19186424300418511%2C0.18786141133986681%2C0.20427102269629802%2C0.20827385436061632%26cropmode%3Dpercentage%26width%3D800%26height%3D800%26rnd%3D132951122240000000%26overlay%3Dwatermark.png%26overlay.size%3D230%2C20%26overlay.position%3D0%2C780`
+  return `${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}${track?.Media[0]?.Part[0]?.$.key}?X-Plex-Token=${plexServer.token}&squeezePlexHub_rk=${track.$.ratingKey}`  
 }
 
 /**


### PR DESCRIPTION
This pull request updates the construction of Plex API track URLs to include the `ratingKey` as an additional query parameter. This allows compatibility with [LMS Squeeze Plex Hub Plugin](https://github.com/onmomo/lms-squeeze-plex-hub) to show track metadata fetched from Plex on LMS.

<img width="968" height="677" alt="Screenshot 2026-01-21 at 22 51 15" src="https://github.com/user-attachments/assets/8f828291-1aa9-44f0-a7ed-fc724115149c" />
