### PR TITLE
#82 improve udp port binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ On the device the project should be executed:
 ### Squeeze players not found in Plexamp:
   1. Verify any Squeezebox player is connected and available in Lyrion / LMS first.
   2. Check Squeeze Plex Hub (http://localhost:3000) dashboard and confirm both LMS and Squeezebox players are shown. If nothing is shown, ensure Squeeze Plex Hub can connect to Lyrion / LMS and that the Lyrion CLI is enabled.
-3. Check for port conflicts by reviewing the Squeeze Plex Hub startup logs for any discovery or network errors. This is especially important if both Squeeze Plex Hub and Plex Media Server are running on the same host. Squeeze Plex Hub requires exclusive access to UDP port 32412 to handle GDM network discovery requests from Plex clients. If Plex Media Server is also binding to this port, it may cause conflicts—Plex typically falls back to other ports in the range (32410, 32412, 32413, 32414). To resolve this, remove port 32412 from Plex Media Server if possible. If TCP port 3000 is already in use, you can publish a different host port (e.g., `docker run -p 8080:3000 ...`) and access the app at `http://localhost:8080`. For more details on proper container deployment and networking, refer to the Container Networking section below.
+3. Check for port conflicts by reviewing the Squeeze Plex Hub startup logs for any discovery or network errors. This is especially important if both Squeeze Plex Hub and Plex Media Server are running on the same host. Squeeze Plex Hub requires access to UDP port 32412 to handle GDM network player discovery requests from Plex clients. If PMS is running on the same host or docker host network, both services should be able to use UDP 32412. If PMS is running in Docker bridge mode, remove port 32412 from the port mapping. If TCP port 3000 is already in use, you can publish a different host port (e.g., `docker run -p 8080:3000 ...`) and access the app at `http://localhost:8080`. For more details on proper container deployment and networking, refer to the Container Networking section below.
   - Docker Desktop on **MacOS**: GDM network discovery may not work with Docker Desktop on MacOS due to limitations with containers receiving UDP broadcast requests from the host network even if the container is running in **host network mode**. For full functionality in a container, run Docker on Linux.
   4. Ensure no local firewall blocking UDP ports 32412
   4. If still not available, abort Plexamp app to trigger device re-discovery.
@@ -166,8 +166,8 @@ Alternatively, use the published multi-arch image: `onmomo/squeeze-plex-hub:late
 ### Container Networking
 Squeeze Plex Hub listens for UDP broadcast on port `32412` from Plex clients and responds with the discovered players. Therefore, it is essential that it can receive these UDP requests on that specific port.
 - For best results, run the Plex Server container in either `host` or `bridge` network mode, and **always** run Squeeze Plex Hub in `host` network mode. This ensures Plexamp clients on mobile devices connected to your local network can discover Squeezebox players. Docker does not forward UDP packets from the host network (e.g. mobile devices) to the bridge network.
-- **Important:** If Plex Server is in `host` mode, always start Squeeze Plex Hub before Plex Server so it can bind to UDP port `32412`. If Plex Server starts first and binds this port, Squeeze Plex Hub will not work.
-- In `bridge` mode, do **not** bind UDP port `32412` for Plex Server, then the startup order does not matter; it will automatically fallback to other available UDP ports.
+- **Important:** If Plex Server is in `host` mode, always start Squeeze Plex Hub before Plex Server so it will always bind to UDP port `32412`. If Plex Server starts first and binds this port, Squeeze Plex Hub will eventually not work and crash.
+- In `bridge` mode, do **not** bind UDP port `32412` for Plex Server, then the startup order does not matter;
 
 ## Disclaimer  
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Alternatively, use the published multi-arch image: `onmomo/squeeze-plex-hub:late
 Squeeze Plex Hub listens for UDP broadcast on port `32412` from Plex clients and responds with the discovered players. Therefore, it is essential that it can receive these UDP requests on that specific port.
 - For best results, run the Plex Server container in either `host` or `bridge` network mode, and **always** run Squeeze Plex Hub in `host` network mode. This ensures Plexamp clients on mobile devices connected to your local network can discover Squeezebox players. Docker does not forward UDP packets from the host network (e.g. mobile devices) to the bridge network.
 - **Important:** If Plex Server is in `host` mode, always start Squeeze Plex Hub before Plex Server so it will always bind to UDP port `32412`. If Plex Server starts first and binds this port, Squeeze Plex Hub will eventually not work and crash.
-- In `bridge` mode, do **not** bind UDP port `32412` for Plex Server, then the startup order does not matter;
+- In `bridge` mode, do **not** bind UDP port `32412` for Plex Server, then the startup order does not matter.
 
 ## Disclaimer  
 

--- a/server/lib/plexApi.ts
+++ b/server/lib/plexApi.ts
@@ -33,6 +33,7 @@ export const responseHeaders = (playerId: string, playerName: string, contentTyp
   })
 
 export function getPlexApi(plexServer: PlexServer, path: string): string {
+  logger.debug(`Generating Plex API URL for path '${path}' on server '${plexServer.server.name}' (${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}) ..`)
   return `${plexServer.server.protocol}://${plexServer.server.localAddress}:${plexServer.server.port}${path}`
 }
 

--- a/server/plugins/gdmAnnouncer.spec.ts
+++ b/server/plugins/gdmAnnouncer.spec.ts
@@ -57,7 +57,7 @@ describe('gdmAnnouncer', () => {
     expect(server.on).toHaveBeenCalledWith('listening', expect.any(Function))
     expect(server.on).toHaveBeenCalledWith('message', expect.any(Function))
     expect(server.on).toHaveBeenCalledWith('error', expect.any(Function))
-    expect(server.bind).toHaveBeenCalledWith(32412)
+    expect(server.bind).toHaveBeenCalledWith(32410)
   })
 
   it('should handle listening event and set multicast options', () => {
@@ -88,6 +88,26 @@ describe('gdmAnnouncer', () => {
     const msg = Buffer.from('M-SEARCH * HTTP/1.1')
     await messageHandler(msg, { address: '1.2.3.4', port: 12345 })
     expect(server.send).not.toHaveBeenCalled()
+  })
+
+  it('should exit application when all ports are blocked', () => {
+    // Mock process.exit to prevent test from actually exiting
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`process.exit called with code ${code}`)
+    })
+
+    // Mock bind to throw error for all attempts
+    server.bind = vi.fn(() => {
+      throw new Error('EADDRINUSE')
+    })
+
+    // Expect the function to throw due to process.exit
+    expect(() => runGdmAnnouncer()).toThrow('process.exit called with code 1')
+
+    // Verify process.exit was called with code 1
+    expect(mockExit).toHaveBeenCalledWith(1)
+
+    mockExit.mockRestore()
   })
 
   it('should handle errors gracefully', () => {

--- a/server/plugins/gdmAnnouncer.spec.ts
+++ b/server/plugins/gdmAnnouncer.spec.ts
@@ -57,7 +57,7 @@ describe('gdmAnnouncer', () => {
     expect(server.on).toHaveBeenCalledWith('listening', expect.any(Function))
     expect(server.on).toHaveBeenCalledWith('message', expect.any(Function))
     expect(server.on).toHaveBeenCalledWith('error', expect.any(Function))
-    expect(server.bind).toHaveBeenCalledWith(32410)
+    expect(server.bind).toHaveBeenCalledWith(32412)
   })
 
   it('should handle listening event and set multicast options', () => {
@@ -90,13 +90,13 @@ describe('gdmAnnouncer', () => {
     expect(server.send).not.toHaveBeenCalled()
   })
 
-  it('should exit application when all ports are blocked', () => {
+  it('should exit application when port is blocked', () => {
     // Mock process.exit to prevent test from actually exiting
     const mockExit = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
       throw new Error(`process.exit called with code ${code}`)
     })
 
-    // Mock bind to throw error for all attempts
+    // Mock bind to throw error
     server.bind = vi.fn(() => {
       throw new Error('EADDRINUSE')
     })

--- a/server/plugins/gdmAnnouncer.ts
+++ b/server/plugins/gdmAnnouncer.ts
@@ -4,8 +4,8 @@ import useLogger from '../composables/useLogger'
 import type { IPlayerInfo } from 'lms-squeeze-rpc-x/dist/modelTypes'
 import { plexOptions } from '../lib/squeezePlexHub'
 
-// GDM network discovery ports to try
-const gdmAnnouncerPorts = [32410, 32412, 32413, 32414]
+// GDM network player discovery port
+const gdmPlayerAnnouncerPort = 32412
 const logger = useLogger('gdmAnnouncer')
 
 export default defineNitroPlugin(() => {
@@ -21,75 +21,63 @@ export function runGdmAnnouncer() {
   const storage = useStorage('DISCOVERY')
   const decoder = new StringDecoder('utf8')
   
-  // Try to bind to one of the available ports
-  let boundPort: number | null = null
-  
-  for (const port of gdmAnnouncerPorts) {
-    try {
-      // Enable SO_REUSEPORT for multiple instances of the same service to bind to the same port
-      // Essential that we can run multiple Plex clients or server next to Squeeze Plex Hub on the same host
-      const server = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+  try {
+    // Enable SO_REUSEPORT for multiple instances of the same service to bind to the same port
+    // Essential that we can run multiple Plex clients or server next to Squeeze Plex Hub on the same host
+    const server = dgram.createSocket({ type: 'udp4', reuseAddr: true })
 
-      server.on('listening', () => {
-        try {
-          server.addMembership('239.255.255.250')
-          server.setMulticastTTL(5)
-          server.setTTL(64)
-          logger.info(`GDM Announcer is listening on port ${port} to announce LMS squeeze players ..`)
-        } catch (error) {
-          logger.warn('Error listening for gdm messages:', error)
-        }
-      })
+    server.on('listening', () => {
+      try {
+        server.addMembership('239.255.255.250')
+        server.setMulticastTTL(5)
+        server.setTTL(64)
+        logger.info(`GDM Announcer is listening on port ${gdmPlayerAnnouncerPort} to announce LMS squeeze players ..`)
+      } catch (error) {
+        logger.warn('Error listening for gdm messages:', error)
+      }
+    })
 
-      server.on('message', async (msg, rinfo) => {
-        try {
-          const packetContent = decoder.write(msg).trim()
-          if (packetContent.match(/M-SEARCH \* HTTP\/1\.[0-1]/)) {
-            logger.debug(`Received GDM discovery request from ${rinfo.address}:${rinfo.port}`)
-            await storage.getKeys('players/').then(async (serverKey) => {
-              if (!serverKey) {
-                logger.debug('No LMS found in storage, skipping')
-                return
-              }
+    server.on('message', async (msg, rinfo) => {
+      try {
+        const packetContent = decoder.write(msg).trim()
+        if (packetContent.match(/M-SEARCH \* HTTP\/1\.[0-1]/)) {
+          logger.debug(`Received GDM discovery request from ${rinfo.address}:${rinfo.port}`)
+          await storage.getKeys('players/').then(async (serverKey) => {
+            if (!serverKey) {
+              logger.debug('No LMS found in storage, skipping')
+              return
+            }
 
-              for (const key of serverKey) {
-                const playerInfos = await storage.getItem<IPlayerInfo[]>(key)
-                if (playerInfos) {
-                  logger.info(
-                    `Announcing '${playerInfos.length}' players from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
+            for (const key of serverKey) {
+              const playerInfos = await storage.getItem<IPlayerInfo[]>(key)
+              if (playerInfos) {
+                logger.info(
+                  `Announcing '${playerInfos.length}' players from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
+                )
+                for (const playerInfo of playerInfos) {
+                  logger.debug(
+                    `Announcing squeeze player '${playerInfo.name}' from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
                   )
-                  for (const playerInfo of playerInfos) {
-                    logger.debug(
-                      `Announcing squeeze player '${playerInfo.name}' from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
-                    )
-                    const message = announceMessage(playerInfo)
-                    server.send(message, 0, message.length, rinfo.port, rinfo.address)
-                  }
+                  const message = announceMessage(playerInfo)
+                  server.send(message, 0, message.length, rinfo.port, rinfo.address)
                 }
               }
-            })
-          }
-        } catch (error) {
-          logger.warn('Error processing received gdm message:', error)
+            }
+          })
         }
-      })
+      } catch (error) {
+        logger.warn('Error processing received gdm message:', error)
+      }
+    })
 
-      server.on('error', (err) => {
-        logger.error('Error on gdm announcer:', err)
-        server.close()
-      })
+    server.on('error', (err) => {
+      logger.error('Error on gdm announcer:', err)
+      server.close()
+    })
 
-      server.bind(port)
-      boundPort = port
-      break // Successfully bound to a port, exit the loop
-    } catch (error) {
-      logger.warn(`UDP port ${port} is already in use, trying next port...`, error)
-    }
-  }
-  
-  // If no port could be bound, log error and quit
-  if (boundPort === null) {
-    logger.error(`Failed to bind to any of the GDM ports: ${gdmAnnouncerPorts.join(', ')}. Squeeze Plex Hub cannot continue. Ensure one of the UDP ports (32410, 32412, 32413, 32414) is available and not blocked by PMS itself or any other application. If PMS runs in Docker bridge mode, ensure that one of the ports is not mapped to PMS container, otherwise consider switching PMS to host mode or start Squeeze Plex Hub before PMS.`)
+    server.bind(gdmPlayerAnnouncerPort)
+  } catch (error) {
+    logger.error(`Failed to bind to GDM port ${gdmPlayerAnnouncerPort}. Squeeze Plex Hub cannot continue. Ensure the UDP port 32412 is available and not blocked by PMS itself or any other application. If PMS runs in Docker bridge mode, ensure that port 32412 is not mapped to PMS container, otherwise consider running Squeeze Plex Hub in host mode. Alternatively, move Squeeze Plex Hub to another host.`, error)
     process.exit(1)
   }
 }

--- a/server/plugins/gdmAnnouncer.ts
+++ b/server/plugins/gdmAnnouncer.ts
@@ -4,8 +4,8 @@ import useLogger from '../composables/useLogger'
 import type { IPlayerInfo } from 'lms-squeeze-rpc-x/dist/modelTypes'
 import { plexOptions } from '../lib/squeezePlexHub'
 
-// Needs to listen on this UDP port for discovery requests from plex clients in the local network
-const gdmAnnouncerPort = 32412
+// GDM network discovery ports to try
+const gdmAnnouncerPorts = [32410, 32412, 32413, 32414]
 const logger = useLogger('gdmAnnouncer')
 
 export default defineNitroPlugin(() => {
@@ -18,65 +18,79 @@ export default defineNitroPlugin(() => {
  * Announces LMS players to Plex clients using GDM.
  */
 export function runGdmAnnouncer() {
-  try {
-    const storage = useStorage('DISCOVERY')
-    const decoder = new StringDecoder('utf8')
-    // Enable SO_REUSEPORT for multiple instances of the same service to bind to the same port
-    // Essential that we can run multiple Plex clients or server next to Squeeze Plex Hub on the same host
-    const server = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+  const storage = useStorage('DISCOVERY')
+  const decoder = new StringDecoder('utf8')
+  
+  // Try to bind to one of the available ports
+  let boundPort: number | null = null
+  
+  for (const port of gdmAnnouncerPorts) {
+    try {
+      // Enable SO_REUSEPORT for multiple instances of the same service to bind to the same port
+      // Essential that we can run multiple Plex clients or server next to Squeeze Plex Hub on the same host
+      const server = dgram.createSocket({ type: 'udp4', reuseAddr: true })
 
-    server.on('listening', () => {
-      try {
-        server.addMembership('239.255.255.250')
-        server.setMulticastTTL(5)
-        server.setTTL(64)
-        logger.info(`GDM Announcer is listening on port ${gdmAnnouncerPort} to announce LMS squeeze players ..`)
-      } catch (error) {
-        logger.warn('Error listening for gdm messages:', error)
-      }
-    })
+      server.on('listening', () => {
+        try {
+          server.addMembership('239.255.255.250')
+          server.setMulticastTTL(5)
+          server.setTTL(64)
+          logger.info(`GDM Announcer is listening on port ${port} to announce LMS squeeze players ..`)
+        } catch (error) {
+          logger.warn('Error listening for gdm messages:', error)
+        }
+      })
 
-    server.on('message', async (msg, rinfo) => {
-      try {
-        const packetContent = decoder.write(msg).trim()
-        if (packetContent.match(/M-SEARCH \* HTTP\/1\.[0-1]/)) {
-          logger.debug(`Received GDM discovery request from ${rinfo.address}:${rinfo.port}`)
-          await storage.getKeys('players/').then(async (serverKey) => {
-            if (!serverKey) {
-              logger.debug('No LMS found in storage, skipping')
-              return
-            }
+      server.on('message', async (msg, rinfo) => {
+        try {
+          const packetContent = decoder.write(msg).trim()
+          if (packetContent.match(/M-SEARCH \* HTTP\/1\.[0-1]/)) {
+            logger.debug(`Received GDM discovery request from ${rinfo.address}:${rinfo.port}`)
+            await storage.getKeys('players/').then(async (serverKey) => {
+              if (!serverKey) {
+                logger.debug('No LMS found in storage, skipping')
+                return
+              }
 
-            for (const key of serverKey) {
-              const playerInfos = await storage.getItem<IPlayerInfo[]>(key)
-              if (playerInfos) {
-                logger.info(
-                  `Announcing '${playerInfos.length}' players from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
-                )
-                for (const playerInfo of playerInfos) {
-                  logger.debug(
-                    `Announcing squeeze player '${playerInfo.name}' from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
+              for (const key of serverKey) {
+                const playerInfos = await storage.getItem<IPlayerInfo[]>(key)
+                if (playerInfos) {
+                  logger.info(
+                    `Announcing '${playerInfos.length}' players from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
                   )
-                  const message = announceMessage(playerInfo)
-                  server.send(message, 0, message.length, rinfo.port, rinfo.address)
+                  for (const playerInfo of playerInfos) {
+                    logger.debug(
+                      `Announcing squeeze player '${playerInfo.name}' from LMS '${key}' to Plex client '${rinfo.address}:${rinfo.port}' ..`
+                    )
+                    const message = announceMessage(playerInfo)
+                    server.send(message, 0, message.length, rinfo.port, rinfo.address)
+                  }
                 }
               }
-            }
-          })
+            })
+          }
+        } catch (error) {
+          logger.warn('Error processing received gdm message:', error)
         }
-      } catch (error) {
-        logger.warn('Error processing received gdm message:', error)
-      }
-    })
+      })
 
-    server.on('error', (err) => {
-      logger.error('Error on gdm announcer:', err)
-      server.close()
-    })
+      server.on('error', (err) => {
+        logger.error('Error on gdm announcer:', err)
+        server.close()
+      })
 
-    server.bind(gdmAnnouncerPort)
-  } catch (error) {
-    logger.warn(`Error announcing squeeze players on port ${gdmAnnouncerPort}:`, error)
+      server.bind(port)
+      boundPort = port
+      break // Successfully bound to a port, exit the loop
+    } catch (error) {
+      logger.warn(`UDP port ${port} is already in use, trying next port...`, error)
+    }
+  }
+  
+  // If no port could be bound, log error and quit
+  if (boundPort === null) {
+    logger.error(`Failed to bind to any of the GDM ports: ${gdmAnnouncerPorts.join(', ')}. Squeeze Plex Hub cannot continue. Ensure one of the UDP ports (32410, 32412, 32413, 32414) is available and not blocked by PMS itself or any other application. If PMS runs in Docker bridge mode, ensure that one of the ports is not mapped to PMS container, otherwise consider switching PMS to host mode or start Squeeze Plex Hub before PMS.`)
+    process.exit(1)
   }
 }
 

--- a/server/routes/player/timeline/poll.get.ts
+++ b/server/routes/player/timeline/poll.get.ts
@@ -119,7 +119,7 @@ export default eventHandler(async (event) => {
     if (queryParameters.wait === '1') {
       // don't send timeline response immediately, wait for player to change state and send timeline response in timelinePublisher
       await storage.setItem(`subscribers/${targetClientIdentifier}/${clientIdentifier}`, subscriber)
-      logger.info(`Client '${clientIdentifier}' subscribed to player '${playerInfo.name}' for polling (wait = 1)`)
+      logger.debug(`Client '${clientIdentifier}' subscribed to player '${playerInfo.name}' for polling (wait = 1)`)
       // TODO don't really understand the wait === 1 logic, this works as a workaround for now to prevent the client going wild with subscribing
       await new Promise((resolve) => setTimeout(resolve, 1000))
       const status = await player.status()

--- a/server/tasks/gdmDiscovery.spec.ts
+++ b/server/tasks/gdmDiscovery.spec.ts
@@ -1,43 +1,140 @@
-import { describe, it, expect } from 'vitest'
-import { parseServerResponse } from './gdmDiscovery'
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import axios from 'axios'
+import { parseServerResponse, verifyPlexServerConnectivity } from './gdmDiscovery'
 
-describe('parseServerResponse', () => {
-  const validResponse = [
-    'HTTP/1.0 200 OK',
-    'Content-Type: plex/media-server',
-    'Host: ztea2cf712e03f2b540150acfe3a4b.plex.direct',
-    'Name: My Plex Server',
-    'Port: 32400',
-    'Resource-Identifier: abcd1234',
-    'Updated-At: 1710000000',
-    'Version: 1.32.0.0',
-    ''
-  ].join('\n')
+vi.mock('axios')
 
-  it('parses a valid Plex server response', () => {
-    const result = parseServerResponse(validResponse, '192.168.1.10')
-    expect(result).toEqual({
-      protocol: 'http',
-      contentType: 'plex/media-server',
-      host: 'ztea2cf712e03f2b540150acfe3a4b.plex.direct',
-      name: 'My Plex Server',
-      port: 32400,
-      resourceIdentifier: 'abcd1234',
-      updatedAt: 1710000000,
-      version: '1.32.0.0',
-      localAddress: '192.168.1.10',
-      secureAddress: '192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct',
-      secureProtocol: 'https'
+vi.mock('../composables/useLogger', () => ({
+  default: () => ({
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn()
+  })
+}))
+
+describe('gdmDiscovery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('parseServerResponse', () => {
+    const validResponse = [
+      'HTTP/1.0 200 OK',
+      'Content-Type: plex/media-server',
+      'Host: ztea2cf712e03f2b540150acfe3a4b.plex.direct',
+      'Name: My Plex Server',
+      'Port: 32400',
+      'Resource-Identifier: abcd1234',
+      'Updated-At: 1710000000',
+      'Version: 1.32.0.0',
+      ''
+    ].join('\n')
+
+    it('parses a valid Plex server response', () => {
+      const result = parseServerResponse(validResponse, '192.168.1.10')
+      expect(result).toEqual({
+        protocol: 'http',
+        contentType: 'plex/media-server',
+        host: 'ztea2cf712e03f2b540150acfe3a4b.plex.direct',
+        name: 'My Plex Server',
+        port: 32400,
+        resourceIdentifier: 'abcd1234',
+        updatedAt: 1710000000,
+        version: '1.32.0.0',
+        localAddress: '192.168.1.10',
+        secureAddress: '192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct',
+        secureProtocol: 'https'
+      })
+    })
+
+    it('returns undefined for incomplete response', () => {
+      const incomplete = 'HTTP/1.0 200 OK\nContent-Type: plex/media-server\n'
+      expect(parseServerResponse(incomplete, '192.168.1.10')).toBeUndefined()
+    })
+
+    it('returns null for missing required fields', () => {
+      const missing = ['HTTP/1.0 200 OK', 'Content-Type: plex/media-server', 'Host: ztea2cf712e03f2b540150acfe3a4b.plex.direct', 'Port: 32400', ''].join('\n')
+      expect(parseServerResponse(missing, '192.168.1.10')).toBeUndefined()
     })
   })
 
-  it('returns undefined for incomplete response', () => {
-    const incomplete = 'HTTP/1.0 200 OK\nContent-Type: plex/media-server\n'
-    expect(parseServerResponse(incomplete, '192.168.1.10')).toBeUndefined()
-  })
+  describe('verifyPlexServerConnectivity', () => {
+    it('should successfully verify connectivity when axios.get succeeds', async () => {
+      ;(axios.get as Mock).mockResolvedValue({ data: {} })
 
-  it('returns null for missing required fields', () => {
-    const missing = ['HTTP/1.0 200 OK', 'Content-Type: plex/media-server', 'Host: ztea2cf712e03f2b540150acfe3a4b.plex.direct', 'Port: 32400', ''].join('\n')
-    expect(parseServerResponse(missing, '192.168.1.10')).toBeUndefined()
+      await expect(verifyPlexServerConnectivity('http://192.168.1.10:32400/identity')).resolves.toBeUndefined()
+
+      expect(axios.get).toHaveBeenCalledWith('http://192.168.1.10:32400/identity', {
+        timeout: 3000
+      })
+    })
+
+    it('should throw and log error for axios errors', async () => {
+      const axiosError = {
+        message: 'Network Error',
+        code: 'ECONNREFUSED',
+        response: {
+          status: 500,
+          statusText: 'Internal Server Error'
+        },
+        isAxiosError: true
+      }
+      ;(axios.get as Mock).mockRejectedValue(axiosError)
+      ;(axios.isAxiosError as Mock).mockReturnValue(true)
+
+      await expect(verifyPlexServerConnectivity('http://192.168.1.10:32400/identity')).rejects.toEqual(axiosError)
+
+      expect(axios.get).toHaveBeenCalledWith('http://192.168.1.10:32400/identity', {
+        timeout: 3000
+      })
+    })
+
+    it('should handle DNS resolution failures for *.plex.direct URLs', async () => {
+      const dnsError = {
+        message: 'getaddrinfo ENOTFOUND 192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct',
+        code: 'ENOTFOUND',
+        isAxiosError: true
+      }
+      ;(axios.get as Mock).mockRejectedValue(dnsError)
+      ;(axios.isAxiosError as Mock).mockReturnValue(true)
+
+      await expect(
+        verifyPlexServerConnectivity('https://192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct:32400/identity')
+      ).rejects.toEqual(dnsError)
+
+      expect(axios.get).toHaveBeenCalledWith(
+        'https://192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct:32400/identity',
+        {
+          timeout: 3000
+        }
+      )
+    })
+
+    it('should handle unexpected errors', async () => {
+      const unexpectedError = new Error('Unexpected error')
+      ;(axios.get as Mock).mockRejectedValue(unexpectedError)
+      ;(axios.isAxiosError as Mock).mockReturnValue(false)
+
+      await expect(verifyPlexServerConnectivity('http://192.168.1.10:32400/identity')).rejects.toThrow('Unexpected error')
+
+      expect(axios.get).toHaveBeenCalledWith('http://192.168.1.10:32400/identity', {
+        timeout: 3000
+      })
+    })
+
+    it('should verify both local and secure URLs', async () => {
+      ;(axios.get as Mock).mockResolvedValue({ data: {} })
+
+      const localUrl = 'http://192.168.1.10:32400/identity'
+      const secureUrl = 'https://192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct:32400/identity'
+
+      await expect(verifyPlexServerConnectivity(localUrl)).resolves.toBeUndefined()
+      await expect(verifyPlexServerConnectivity(secureUrl)).resolves.toBeUndefined()
+
+      expect(axios.get).toHaveBeenCalledWith(localUrl, { timeout: 3000 })
+      expect(axios.get).toHaveBeenCalledWith(secureUrl, { timeout: 3000 })
+      expect(axios.get).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/server/tasks/gdmDiscovery.spec.ts
+++ b/server/tasks/gdmDiscovery.spec.ts
@@ -5,7 +5,7 @@ describe('parseServerResponse', () => {
   const validResponse = [
     'HTTP/1.0 200 OK',
     'Content-Type: plex/media-server',
-    'Host: 192.168.1.10',
+    'Host: ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct',
     'Name: My Plex Server',
     'Port: 32400',
     'Resource-Identifier: abcd1234',
@@ -19,14 +19,14 @@ describe('parseServerResponse', () => {
     expect(result).toEqual({
       protocol: 'http',
       contentType: 'plex/media-server',
-      host: '192.168.1.10',
+      host: 'ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct',
       name: 'My Plex Server',
       port: 32400,
       resourceIdentifier: 'abcd1234',
       updatedAt: 1710000000,
       version: '1.32.0.0',
       localAddress: '192.168.1.10',
-      secureAddress: '192-168-1-10.192.168.1.10',
+      secureAddress: '192-168-1-10.ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct',
       secureProtocol: 'https'
     })
   })
@@ -37,7 +37,7 @@ describe('parseServerResponse', () => {
   })
 
   it('returns null for missing required fields', () => {
-    const missing = ['HTTP/1.0 200 OK', 'Content-Type: plex/media-server', 'Host: 192.168.1.10', 'Port: 32400', ''].join('\n')
+    const missing = ['HTTP/1.0 200 OK', 'Content-Type: plex/media-server', 'Host: ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct', 'Port: 32400', ''].join('\n')
     expect(parseServerResponse(missing, '192.168.1.10')).toBeUndefined()
   })
 })

--- a/server/tasks/gdmDiscovery.spec.ts
+++ b/server/tasks/gdmDiscovery.spec.ts
@@ -26,8 +26,8 @@ describe('parseServerResponse', () => {
       updatedAt: 1710000000,
       version: '1.32.0.0',
       localAddress: '192.168.1.10',
-      relayAddress: '192-168-1-10.192.168.1.10',
-      relayProtocol: 'https'
+      secureAddress: '192-168-1-10.192.168.1.10',
+      secureProtocol: 'https'
     })
   })
 

--- a/server/tasks/gdmDiscovery.spec.ts
+++ b/server/tasks/gdmDiscovery.spec.ts
@@ -5,7 +5,7 @@ describe('parseServerResponse', () => {
   const validResponse = [
     'HTTP/1.0 200 OK',
     'Content-Type: plex/media-server',
-    'Host: ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct',
+    'Host: ztea2cf712e03f2b540150acfe3a4b.plex.direct',
     'Name: My Plex Server',
     'Port: 32400',
     'Resource-Identifier: abcd1234',
@@ -19,14 +19,14 @@ describe('parseServerResponse', () => {
     expect(result).toEqual({
       protocol: 'http',
       contentType: 'plex/media-server',
-      host: 'ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct',
+      host: 'ztea2cf712e03f2b540150acfe3a4b.plex.direct',
       name: 'My Plex Server',
       port: 32400,
       resourceIdentifier: 'abcd1234',
       updatedAt: 1710000000,
       version: '1.32.0.0',
       localAddress: '192.168.1.10',
-      secureAddress: '192-168-1-10.ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct',
+      secureAddress: '192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct',
       secureProtocol: 'https'
     })
   })
@@ -37,7 +37,7 @@ describe('parseServerResponse', () => {
   })
 
   it('returns null for missing required fields', () => {
-    const missing = ['HTTP/1.0 200 OK', 'Content-Type: plex/media-server', 'Host: ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct', 'Port: 32400', ''].join('\n')
+    const missing = ['HTTP/1.0 200 OK', 'Content-Type: plex/media-server', 'Host: ztea2cf712e03f2b540150acfe3a4b.plex.direct', 'Port: 32400', ''].join('\n')
     expect(parseServerResponse(missing, '192.168.1.10')).toBeUndefined()
   })
 })

--- a/server/tasks/gdmDiscovery.spec.ts
+++ b/server/tasks/gdmDiscovery.spec.ts
@@ -81,7 +81,7 @@ describe('gdmDiscovery', () => {
         isAxiosError: true
       }
       ;(axios.get as Mock).mockRejectedValue(axiosError)
-      ;(axios.isAxiosError as Mock).mockReturnValue(true)
+      ;(axios.isAxiosError as unknown as Mock).mockReturnValue(true)
 
       await expect(verifyPlexServerConnectivity('http://192.168.1.10:32400/identity')).rejects.toEqual(axiosError)
 
@@ -97,7 +97,7 @@ describe('gdmDiscovery', () => {
         isAxiosError: true
       }
       ;(axios.get as Mock).mockRejectedValue(dnsError)
-      ;(axios.isAxiosError as Mock).mockReturnValue(true)
+      ;(axios.isAxiosError as unknown as Mock).mockReturnValue(true)
 
       await expect(
         verifyPlexServerConnectivity('https://192-168-1-10.ztea2cf712e03f2b540150acfe3a4b.plex.direct:32400/identity')
@@ -114,7 +114,7 @@ describe('gdmDiscovery', () => {
     it('should handle unexpected errors', async () => {
       const unexpectedError = new Error('Unexpected error')
       ;(axios.get as Mock).mockRejectedValue(unexpectedError)
-      ;(axios.isAxiosError as Mock).mockReturnValue(false)
+      ;(axios.isAxiosError as unknown as Mock).mockReturnValue(false)
 
       await expect(verifyPlexServerConnectivity('http://192.168.1.10:32400/identity')).rejects.toThrow('Unexpected error')
 

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -1,4 +1,6 @@
 import dgram from 'dgram'
+import type { AxiosError } from 'axios';
+import axios from 'axios'
 import useLogger from '../composables/useLogger'
 
 const broadcastAddress = '239.255.255.250'
@@ -74,6 +76,28 @@ async function runGdmDiscovery() {
         logger.info(
           `Discovered PLEX server '${plexServer.name}' at ${plexServer.localAddress}:${plexServer.port} (host: ${plexServer.host})`
         )
+        
+        // Verify connectivity to the Plex server
+        const verifyUrl = `${plexServer.protocol}://${plexServer.localAddress}:${plexServer.port}/identity`
+        try {        
+          logger.debug(`Verifying connectivity to PMS at ${verifyUrl}`)
+          await axios.get(verifyUrl, {
+            timeout: 3000
+          })
+                    
+          logger.info(`Successfully verified connectivity to PMS '${plexServer.name}@${verifyUrl}' - PMS is reachable and ready to be used in Squeeze Plex Hub.`)
+        } catch (error) {
+          if (axios.isAxiosError(error)) {
+            const axiosError: AxiosError = error
+            logger.warn(`Failed to verify connectivity to PMS at ${verifyUrl}. Squeeze Plex Hub won't be able to stream from this server.`, {
+              message: axiosError.message,
+              code: axiosError.code,
+            })
+          } else {
+            logger.warn(`Unexpected error while connecting to PMS, failed to verify connectivity to PMS at ${verifyUrl}:`, error)
+          }          
+        }
+        
         await storage.setItem(`plexServer`, plexServer)
         discoverySocket.close()
       }

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -2,7 +2,6 @@ import dgram from 'dgram'
 import type { AxiosError } from 'axios'
 import axios from 'axios'
 import useLogger from '../composables/useLogger'
-import { th, tr } from '@nuxt/ui/runtime/locale/index.js'
 
 const broadcastAddress = '239.255.255.250'
 const discoveryMessage = 'M-SEARCH * HTTP/1.1\r\n\r\n'

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -2,7 +2,6 @@ import dgram from 'dgram'
 import type { AxiosError } from 'axios'
 import axios from 'axios'
 import useLogger from '../composables/useLogger'
-import { a } from 'vitest/dist/chunks/suite.d.FvehnV49.js'
 
 const broadcastAddress = '239.255.255.250'
 const discoveryMessage = 'M-SEARCH * HTTP/1.1\r\n\r\n'

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -4,7 +4,7 @@ import useLogger from '../composables/useLogger'
 const broadcastAddress = '239.255.255.250'
 const discoveryMessage = 'M-SEARCH * HTTP/1.1\r\n\r\n'
 // needs to broadcast on this port to receive a response from plex servers in the local network
-const discoveryPort = 32414
+const pmsDiscoveryPort = 32414
 
 /**
  * Task to discover Plex servers on the local network using GDM (Global Discovery and Management) protocol.
@@ -55,7 +55,7 @@ async function runGdmDiscovery() {
     })
 
     const messageBuffer = Buffer.from(discoveryMessage)
-    discoverySocket.send(messageBuffer, 0, messageBuffer.length, discoveryPort, broadcastAddress, (err) => {
+    discoverySocket.send(messageBuffer, 0, messageBuffer.length, pmsDiscoveryPort, broadcastAddress, (err) => {
       if (err) {
         logger.error('Error sending discovery packet:', err)
         discoverySocket.close()

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -2,6 +2,7 @@ import dgram from 'dgram'
 import type { AxiosError } from 'axios'
 import axios from 'axios'
 import useLogger from '../composables/useLogger'
+import { th, tr } from '@nuxt/ui/runtime/locale/index.js'
 
 const broadcastAddress = '239.255.255.250'
 const discoveryMessage = 'M-SEARCH * HTTP/1.1\r\n\r\n'
@@ -79,14 +80,19 @@ async function runGdmDiscovery() {
 
         // Verify connectivity to the Plex server
         const verifyUrl = `${plexServer.protocol}://${plexServer.localAddress}:${plexServer.port}/identity`
-        // Plexamp will provide the secure address (192-168-1-5.ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct) along the squeeze player requests,
+        // Plexamp will provide the secure address (192-168-1-5.ztea2cf712e03f2b540150acfe3a4b.plex.direct) along the squeeze player requests,
         // so we need to ensure it is reachable as well to prevent connectivity issues later on when the secure address is used for streaming or talking to the Plex server API.
         const verifySecureUrl = `${plexServer.secureProtocol}://${plexServer.secureAddress}:${plexServer.port}/identity`
-
-        await verifyPlexServerConnectivity(verifyUrl)
-        await verifyPlexServerConnectivity(verifySecureUrl)
-        await storage.setItem(`plexServer`, plexServer)
-        discoverySocket.close()
+        try {
+          await verifyPlexServerConnectivity(verifyUrl)
+          await verifyPlexServerConnectivity(verifySecureUrl)
+          await storage.setItem(`plexServer`, plexServer)
+        } catch (error) {
+          // Skip storing this server since it does not appear to be reachable, but log the error for debugging purposes
+          logger.error(error)
+        } finally {
+          discoverySocket.close()
+        }
       }
     })
 
@@ -124,6 +130,7 @@ async function runGdmDiscovery() {
       } else {
         logger.error(`Unexpected error while connecting to PMS, failed to verify connectivity to PMS at ${verifyUrl}:`, error)
       }
+      throw error
     }
   }
 }

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -2,7 +2,6 @@ import dgram from 'dgram'
 import type { AxiosError } from 'axios'
 import axios from 'axios'
 import useLogger from '../composables/useLogger'
-import { th, tr } from '@nuxt/ui/runtime/locale/index.js'
 
 const broadcastAddress = '239.255.255.250'
 const discoveryMessage = 'M-SEARCH * HTTP/1.1\r\n\r\n'
@@ -107,31 +106,32 @@ async function runGdmDiscovery() {
   } catch (error) {
     logger.error('Error during GDM Discovery:', error)
   }
+}
 
-  async function verifyPlexServerConnectivity(verifyUrl: string): Promise<void> {
-    try {
-      logger.debug(`Verifying connectivity to PMS at ${verifyUrl}`)
-      await axios.get(verifyUrl, {
-        timeout: 3000
-      })
+export async function verifyPlexServerConnectivity(verifyUrl: string): Promise<void> {
+  const logger = useLogger('gdmDiscovery')
+  try {
+    logger.debug(`Verifying connectivity to PMS at ${verifyUrl}`)
+    await axios.get(verifyUrl, {
+      timeout: 3000
+    })
 
-      logger.info(`Successfully verified connectivity to PMS@'${verifyUrl}' - PMS is reachable and ready to be used with Squeeze Plex Hub.`)
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        const axiosError: AxiosError = error
-        logger.error(
-          `Failed to verify connectivity to PMS at ${verifyUrl}. Squeeze Plex Hub won't be able to stream. For *.plex.direct urls, ensure DNS resolution is working correctly: ${axiosError.message}`,
-          {
-            code: axiosError.code,
-            status: axiosError.response?.status,
-            statusText: axiosError.response?.statusText
-          }
-        )
-      } else {
-        logger.error(`Unexpected error while connecting to PMS, failed to verify connectivity to PMS at ${verifyUrl}:`, error)
-      }
-      throw error
+    logger.info(`Successfully verified connectivity to PMS@'${verifyUrl}' - PMS is reachable and ready to be used with Squeeze Plex Hub.`)
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const axiosError: AxiosError = error
+      logger.error(
+        `Failed to verify connectivity to PMS at ${verifyUrl}. Squeeze Plex Hub won't be able to stream. For *.plex.direct urls, ensure DNS resolution is working correctly: ${axiosError.message}`,
+        {
+          code: axiosError.code,
+          status: axiosError.response?.status,
+          statusText: axiosError.response?.statusText
+        }
+      )
+    } else {
+      logger.error(`Unexpected error while connecting to PMS, failed to verify connectivity to PMS at ${verifyUrl}:`, error)
     }
+    throw error
   }
 }
 

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -1,7 +1,8 @@
 import dgram from 'dgram'
-import type { AxiosError } from 'axios';
+import type { AxiosError } from 'axios'
 import axios from 'axios'
 import useLogger from '../composables/useLogger'
+import { a } from 'vitest/dist/chunks/suite.d.FvehnV49.js'
 
 const broadcastAddress = '239.255.255.250'
 const discoveryMessage = 'M-SEARCH * HTTP/1.1\r\n\r\n'
@@ -35,8 +36,8 @@ export interface PlexServerResponse {
   updatedAt?: number
   version?: string
   localAddress: string
-  relayAddress?: string
-  relayProtocol?: string
+  secureAddress?: string
+  secureProtocol?: string
 }
 
 /**
@@ -76,28 +77,15 @@ async function runGdmDiscovery() {
         logger.info(
           `Discovered PLEX server '${plexServer.name}' at ${plexServer.localAddress}:${plexServer.port} (host: ${plexServer.host})`
         )
-        
+
         // Verify connectivity to the Plex server
         const verifyUrl = `${plexServer.protocol}://${plexServer.localAddress}:${plexServer.port}/identity`
-        try {        
-          logger.debug(`Verifying connectivity to PMS at ${verifyUrl}`)
-          await axios.get(verifyUrl, {
-            timeout: 3000
-          })
-                    
-          logger.info(`Successfully verified connectivity to PMS '${plexServer.name}@${verifyUrl}' - PMS is reachable and ready to be used in Squeeze Plex Hub.`)
-        } catch (error) {
-          if (axios.isAxiosError(error)) {
-            const axiosError: AxiosError = error
-            logger.warn(`Failed to verify connectivity to PMS at ${verifyUrl}. Squeeze Plex Hub won't be able to stream from this server.`, {
-              message: axiosError.message,
-              code: axiosError.code,
-            })
-          } else {
-            logger.warn(`Unexpected error while connecting to PMS, failed to verify connectivity to PMS at ${verifyUrl}:`, error)
-          }          
-        }
-        
+        // Plexamp will provide the secure address (192-168-1-5.ztea2cf712e03fs2b5401s50acfe3a4m.plex.direct) along the squeeze player requests,
+        // so we need to ensure it is reachable as well to prevent connectivity issues later on when the secure address is used for streaming or talking to the Plex server API.
+        const verifySecureUrl = `${plexServer.secureProtocol}://${plexServer.secureAddress}:${plexServer.port}/identity`
+
+        await verifyPlexServerConnectivity(verifyUrl)
+        await verifyPlexServerConnectivity(verifySecureUrl)
         await storage.setItem(`plexServer`, plexServer)
         discoverySocket.close()
       }
@@ -113,6 +101,31 @@ async function runGdmDiscovery() {
     }, 300000)
   } catch (error) {
     logger.error('Error during GDM Discovery:', error)
+  }
+
+  async function verifyPlexServerConnectivity(verifyUrl: string): Promise<void> {
+    try {
+      logger.debug(`Verifying connectivity to PMS at ${verifyUrl}`)
+      await axios.get(verifyUrl, {
+        timeout: 3000
+      })
+
+      logger.info(`Successfully verified connectivity to PMS@'${verifyUrl}' - PMS is reachable and ready to be used with Squeeze Plex Hub.`)
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const axiosError: AxiosError = error
+        logger.error(
+          `Failed to verify connectivity to PMS at ${verifyUrl}. Squeeze Plex Hub won't be able to stream. For *.plex.direct urls, ensure DNS resolution is working correctly: ${axiosError.message}`,
+          {
+            code: axiosError.code,
+            status: axiosError.response?.status,
+            statusText: axiosError.response?.statusText
+          }
+        )
+      } else {
+        logger.error(`Unexpected error while connecting to PMS, failed to verify connectivity to PMS at ${verifyUrl}:`, error)
+      }
+    }
   }
 }
 
@@ -134,8 +147,8 @@ export function parseServerResponse(response: string, localAddress: string): Ple
         break
       case 'Host':
         result.host = value
-        result.relayAddress = localAddress.replace(/\./g, '-') + '.' + value
-        result.relayProtocol = 'https'
+        result.secureAddress = localAddress.replace(/\./g, '-') + '.' + result.host
+        result.secureProtocol = 'https'
         break
       case 'Name':
         result.name = value


### PR DESCRIPTION
This pull request focuses on improving the reliability and clarity of GDM (Global Discovery and Management) network player discovery and connectivity for Squeeze Plex Hub, especially around UDP port usage, error handling, and documentation. The changes include enhanced error reporting and handling when binding to the UDP port, improved verification of Plex server connectivity, and updates to documentation for better deployment guidance.
