### PR TITLE
#89 support changing port

### DIFF
--- a/server/composables/useLogger.ts
+++ b/server/composables/useLogger.ts
@@ -3,7 +3,7 @@ import { createLogger, transports } from 'winston'
 export default function useLogger(service?: string) {
   const { logLevel } = useRuntimeConfig()
   return createLogger({
-    level: logLevel.toLowerCase(),
+    level: logLevel?.toLowerCase(),
     defaultMeta: { service },
     transports: [new transports.Console()]
   })


### PR DESCRIPTION
Set NITRO_PORT or PORT environment variable to run and announce Squeeze Plex Hub and its players on a different host port.