### PR TITLE
fix: support multiple Plex servers in GDM discovery without crashing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,6 +176,7 @@ yarn test:coverage      # with LCOV coverage output
 | Key Pattern | Value Type | Purpose |
 |-------------|-----------|---------|
 | `servers/{serverId}` | `ServerInfo` | LMS server metadata |
+| `plexServers/{resourceIdentifier}` | `PlexServerResponse` | Reachable Plex Media Servers found via GDM (diagnostic only, not read at runtime) |
 | `players/{serverId}` | `IPlayerInfo[]` | Players per LMS server |
 | `subscribers/{playerId}/{clientId}` | `RemoteSubscriber` | Active Plex timeline subscribers |
 | `playerQueue/{playerId}` | `PlayerPlayQueue` | Current play queue |
@@ -284,8 +285,21 @@ lmsScanner plugin (on startup)
             └─ LMS JSON API → player list → store in DISCOVERY
 
 gdmDiscovery task (every minute)
-    └─ LMS JSON API → discover Plex servers → store in DISCOVERY
+    └─ UDP broadcast (port 32414) → every Plex server answers → verify reachability
+            └─ store each under plexServers/{resourceIdentifier}, prune the ones that no longer answer
 ```
+
+### Multiple Plex Media Servers
+
+Several PMS instances on the same network are supported and no server is ever "chosen":
+
+- The hub never picks a PMS itself. Every `createPlayQueue` / `playMedia` request carries the server it belongs to
+  (`protocol`, `address`, `port`, `machineIdentifier`, `token` query parameters), which is stored per player in
+  `playerQueue/{playerId}.plexServer` and reused for the play queue, timelines and stream URLs.
+- `gdmDiscovery` therefore only maintains a diagnostic list of reachable servers under `plexServers/{resourceIdentifier}`.
+  Nothing reads it at runtime — it exists to document GDM discovery and as a basis for future direct Plex API usage.
+- The discovery socket must be closed exactly once per run (all Plex servers answer the same broadcast); a second
+  `close()` throws `ERR_SOCKET_DGRAM_NOT_RUNNING` and crashes the process.
 
 ---
 

--- a/server/tasks/gdmDiscovery.spec.ts
+++ b/server/tasks/gdmDiscovery.spec.ts
@@ -275,6 +275,7 @@ describe('gdmDiscovery', () => {
 
       await completeDiscovery(discovery)
 
+      expect(storageMock.getKeys).toHaveBeenCalledWith('plexServers/')
       expect(storageMock.removeItem).toHaveBeenCalledWith('plexServers:bbb222')
       expect(storageMock.removeItem).not.toHaveBeenCalledWith('plexServers:aaa111')
     })

--- a/server/tasks/gdmDiscovery.spec.ts
+++ b/server/tasks/gdmDiscovery.spec.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { EventEmitter } from 'node:events'
 import axios from 'axios'
-import { parseServerResponse, verifyPlexServerConnectivity } from './gdmDiscovery'
+import { parseServerResponse, runGdmDiscovery, verifyPlexServerConnectivity } from './gdmDiscovery'
 
 vi.mock('axios')
 
@@ -12,6 +13,61 @@ vi.mock('../composables/useLogger', () => ({
     error: vi.fn()
   })
 }))
+
+/**
+ * Minimal dgram socket stub that reproduces the node behaviour we care about:
+ * closing an already closed socket throws ERR_SOCKET_DGRAM_NOT_RUNNING.
+ */
+class FakeSocket extends EventEmitter {
+  closed = false
+  bind = vi.fn((callback?: () => void) => callback?.())
+  setBroadcast = vi.fn()
+  send = vi.fn(
+    (_msg: Buffer, _offset: number, _length: number, _port: number, _address: string, callback?: (error: Error | null) => void) =>
+      callback?.(null)
+  )
+
+  close = vi.fn(() => {
+    if (this.closed) {
+      const error: NodeJS.ErrnoException = new Error('Not running')
+      error.code = 'ERR_SOCKET_DGRAM_NOT_RUNNING'
+      throw error
+    }
+    this.closed = true
+    this.emit('close')
+  })
+}
+
+let fakeSocket: FakeSocket
+
+vi.mock('dgram', () => ({
+  default: {
+    createSocket: vi.fn(() => fakeSocket)
+  }
+}))
+
+const storageMock = {
+  getKeys: vi.fn(),
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn()
+}
+vi.stubGlobal('useStorage', () => storageMock)
+
+const serverResponse = (name: string, resourceIdentifier: string, port = 32400) =>
+  [
+    'HTTP/1.0 200 OK',
+    'Content-Type: plex/media-server',
+    'Host: ztea2cf712e03f2b540150acfe3a4b.plex.direct',
+    `Name: ${name}`,
+    `Port: ${port}`,
+    `Resource-Identifier: ${resourceIdentifier}`,
+    'Updated-At: 1710000000',
+    'Version: 1.32.0.0',
+    ''
+  ].join('\n')
+
+const respond = (response: string, address: string) => fakeSocket.emit('message', Buffer.from(response), { address })
 
 describe('gdmDiscovery', () => {
   beforeEach(() => {
@@ -138,6 +194,102 @@ describe('gdmDiscovery', () => {
       expect(axios.get).toHaveBeenCalledWith(localUrl, { timeout: 3000 })
       expect(axios.get).toHaveBeenCalledWith(secureUrl, { timeout: 3000 })
       expect(axios.get).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('runGdmDiscovery', () => {
+    beforeEach(() => {
+      fakeSocket = new FakeSocket()
+      storageMock.getKeys.mockResolvedValue([])
+      storageMock.setItem.mockResolvedValue(undefined)
+      storageMock.removeItem.mockResolvedValue(undefined)
+      ;(axios.get as Mock).mockResolvedValue({ data: {} })
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    const completeDiscovery = async (discovery: Promise<void>) => {
+      await vi.advanceTimersByTimeAsync(10000)
+      await discovery
+    }
+
+    it('stores every reachable Plex server that answers the broadcast', async () => {
+      const discovery = runGdmDiscovery()
+
+      respond(serverResponse('Server A', 'aaa111'), '192.168.1.10')
+      respond(serverResponse('Server B', 'bbb222'), '192.168.1.11')
+
+      await completeDiscovery(discovery)
+
+      expect(storageMock.setItem).toHaveBeenCalledTimes(2)
+      expect(storageMock.setItem).toHaveBeenCalledWith(
+        'plexServers/aaa111',
+        expect.objectContaining({ name: 'Server A', localAddress: '192.168.1.10' })
+      )
+      expect(storageMock.setItem).toHaveBeenCalledWith(
+        'plexServers/bbb222',
+        expect.objectContaining({ name: 'Server B', localAddress: '192.168.1.11' })
+      )
+    })
+
+    it('closes the discovery socket only once when multiple Plex servers respond', async () => {
+      const discovery = runGdmDiscovery()
+
+      respond(serverResponse('Server A', 'aaa111'), '192.168.1.10')
+      respond(serverResponse('Server B', 'bbb222'), '192.168.1.11')
+
+      await completeDiscovery(discovery)
+
+      expect(fakeSocket.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not close the socket a second time after an error', async () => {
+      const discovery = runGdmDiscovery()
+
+      fakeSocket.emit('error', new Error('network is unreachable'))
+
+      await completeDiscovery(discovery)
+
+      expect(fakeSocket.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores duplicate responses from the same Plex server', async () => {
+      const discovery = runGdmDiscovery()
+
+      respond(serverResponse('Server A', 'aaa111'), '192.168.1.10')
+      respond(serverResponse('Server A', 'aaa111'), '192.168.1.10')
+
+      await completeDiscovery(discovery)
+
+      expect(storageMock.setItem).toHaveBeenCalledTimes(1)
+    })
+
+    it('prunes Plex servers that no longer answer the broadcast', async () => {
+      storageMock.getKeys.mockResolvedValue(['plexServers:aaa111', 'plexServers:bbb222'])
+      const discovery = runGdmDiscovery()
+
+      respond(serverResponse('Server A', 'aaa111'), '192.168.1.10')
+
+      await completeDiscovery(discovery)
+
+      expect(storageMock.removeItem).toHaveBeenCalledWith('plexServers:bbb222')
+      expect(storageMock.removeItem).not.toHaveBeenCalledWith('plexServers:aaa111')
+    })
+
+    it('does not store Plex servers that are unreachable and removes stale entries', async () => {
+      ;(axios.get as Mock).mockRejectedValue(new Error('unreachable'))
+      storageMock.getKeys.mockResolvedValue(['plexServers:aaa111'])
+      const discovery = runGdmDiscovery()
+
+      respond(serverResponse('Server A', 'aaa111'), '192.168.1.10')
+
+      await completeDiscovery(discovery)
+
+      expect(storageMock.setItem).not.toHaveBeenCalled()
+      expect(storageMock.removeItem).toHaveBeenCalledWith('plexServers:aaa111')
     })
   })
 })

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -11,7 +11,7 @@ const pmsDiscoveryPort = 32414
 // so we must not stop at the first one. Stays well below the one minute task schedule so sockets never overlap.
 const discoveryWindowMs = 10000
 // one storage entry per Plex server, keyed by its resource identifier - see `servers/{serverId}` for the LMS equivalent
-const plexServersKeyPrefix = 'plexServers'
+const plexServersKeyPrefix = 'plexServers/'
 
 /**
  * Task to discover Plex servers on the local network using GDM (Global Discovery and Management) protocol.
@@ -151,7 +151,7 @@ export async function runGdmDiscovery(): Promise<void> {
       try {
         await verifyPlexServerConnectivity(verifyUrl)
         await verifyPlexServerConnectivity(verifySecureUrl)
-        await storage.setItem(`${plexServersKeyPrefix}/${plexServer.resourceIdentifier}`, plexServer)
+        await storage.setItem(`${plexServersKeyPrefix}${plexServer.resourceIdentifier}`, plexServer)
         reachableServerIds.add(plexServer.resourceIdentifier)
       } catch (error) {
         // Skip storing this server since it does not appear to be reachable, but log the error for debugging purposes

--- a/server/tasks/gdmDiscovery.ts
+++ b/server/tasks/gdmDiscovery.ts
@@ -7,6 +7,11 @@ const broadcastAddress = '239.255.255.250'
 const discoveryMessage = 'M-SEARCH * HTTP/1.1\r\n\r\n'
 // needs to broadcast on this port to receive a response from plex servers in the local network
 const pmsDiscoveryPort = 32414
+// how long we keep listening for responses - every Plex server on the network answers the same broadcast,
+// so we must not stop at the first one. Stays well below the one minute task schedule so sockets never overlap.
+const discoveryWindowMs = 10000
+// one storage entry per Plex server, keyed by its resource identifier - see `servers/{serverId}` for the LMS equivalent
+const plexServersKeyPrefix = 'plexServers'
 
 /**
  * Task to discover Plex servers on the local network using GDM (Global Discovery and Management) protocol.
@@ -41,16 +46,133 @@ export interface PlexServerResponse {
 
 /**
  * Discovers Plex servers on the local network using GDM (Global Discovery and Management) protocol.
- * Sends a UDP broadcast and parses responses from Plex servers.
- * @returns Promise that resolves to a list of discovered PlexServerResponse objects.
+ * Sends a UDP broadcast and parses the responses of every Plex server that answers within the discovery window.
+ * Reachable servers are stored under `plexServers/{resourceIdentifier}`, servers that no longer answer or are
+ * no longer reachable are removed again, so the storage always reflects the currently usable Plex servers.
+ * @returns Promise that resolves once the discovery window is over and all responses have been processed.
  */
-async function runGdmDiscovery() {
+export async function runGdmDiscovery(): Promise<void> {
   const logger = useLogger('gdmDiscovery')
   const storage = useStorage('DISCOVERY')
   logger.info('Starting GDM Plex server discovery ...')
-  try {
-    // Enable SO_REUSEPORT for multiple instances of the same service to bind to the same port
-    const discoverySocket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+
+  return new Promise<void>((resolve) => {
+    // resource identifiers we already handled in this run, a server may answer the broadcast more than once
+    const respondedServerIds = new Set<string>()
+    // resource identifiers we verified and stored in this run, everything else gets pruned from storage
+    const reachableServerIds = new Set<string>()
+    // responses are processed asynchronously, keep track of them so we only finish once they are all done
+    const pendingResponses: Promise<void>[] = []
+
+    let closed = false
+    let finished = false
+    let discoveryTimeout: NodeJS.Timeout | undefined
+    let discoverySocket: dgram.Socket
+
+    try {
+      // Enable SO_REUSEPORT for multiple instances of the same service to bind to the same port
+      discoverySocket = dgram.createSocket({ type: 'udp4', reuseAddr: true })
+    } catch (error) {
+      logger.error('Error during GDM Discovery:', error)
+      resolve()
+      return
+    }
+
+    /**
+     * Wraps up the discovery run once the socket is closed: awaits the responses still being verified,
+     * prunes servers that are gone and resolves the task. Idempotent, the socket may close more than once.
+     */
+    const finish = () => {
+      if (finished) return
+      finished = true
+      Promise.allSettled(pendingResponses)
+        .then(() => pruneUnreachablePlexServers(reachableServerIds))
+        .catch((error) => logger.error('Error while finishing GDM Discovery:', error))
+        .finally(() => resolve())
+    }
+
+    /**
+     * Closing must be idempotent: multiple Plex servers answer the same broadcast and the timeout as well as
+     * the error handlers may close the socket too. dgram throws ERR_SOCKET_DGRAM_NOT_RUNNING on a second close,
+     * which previously crashed the process as soon as more than one Plex server was on the network.
+     */
+    const closeSocketOnce = () => {
+      if (closed) return
+      closed = true
+      clearTimeout(discoveryTimeout)
+      discoveryTimeout = undefined
+      try {
+        discoverySocket.close()
+      } catch (error) {
+        logger.warn('GDM Discovery socket was already closed:', error)
+        // no 'close' event to expect anymore, wrap up right away
+        finish()
+      }
+    }
+
+    discoverySocket.on('close', finish)
+
+    discoverySocket.on('error', (err) => {
+      logger.error('Error on GDM Discovery:', err)
+      closeSocketOnce()
+    })
+
+    discoverySocket.on('message', (msg, rinfo) => {
+      const responseData = msg.toString()
+      if (!responseData.includes('HTTP/1.0 200 OK')) {
+        return
+      }
+
+      const plexServer = parseServerResponse(responseData, rinfo.address)
+      if (!plexServer || plexServer.contentType !== 'plex/media-server') {
+        logger.warn('Unexpected GDM Discovery response:', responseData)
+        return
+      }
+      if (respondedServerIds.has(plexServer.resourceIdentifier)) {
+        logger.debug(`PLEX server '${plexServer.name}' already handled in this discovery run, skipping duplicate response`)
+        return
+      }
+      respondedServerIds.add(plexServer.resourceIdentifier)
+
+      logger.info(`Discovered PLEX server '${plexServer.name}' at ${plexServer.localAddress}:${plexServer.port} (host: ${plexServer.host})`)
+      // keep listening, further Plex servers on the network may still answer the broadcast
+      pendingResponses.push(storeReachablePlexServer(plexServer))
+    })
+
+    /**
+     * Verifies that the discovered Plex server is reachable and stores it, otherwise it is skipped.
+     */
+    const storeReachablePlexServer = async (plexServer: PlexServerResponse): Promise<void> => {
+      // Verify connectivity to the Plex server
+      const verifyUrl = `${plexServer.protocol}://${plexServer.localAddress}:${plexServer.port}/identity`
+      // Plexamp will provide the secure address (192-168-1-5.ztea2cf712e03f2b540150acfe3a4b.plex.direct) along the squeeze player requests,
+      // so we need to ensure it is reachable as well to prevent connectivity issues later on when the secure address is used for streaming or talking to the Plex server API.
+      const verifySecureUrl = `${plexServer.secureProtocol}://${plexServer.secureAddress}:${plexServer.port}/identity`
+      try {
+        await verifyPlexServerConnectivity(verifyUrl)
+        await verifyPlexServerConnectivity(verifySecureUrl)
+        await storage.setItem(`${plexServersKeyPrefix}/${plexServer.resourceIdentifier}`, plexServer)
+        reachableServerIds.add(plexServer.resourceIdentifier)
+      } catch (error) {
+        // Skip storing this server since it does not appear to be reachable, but log the error for debugging purposes
+        logger.error(error)
+      }
+    }
+
+    /**
+     * Removes previously discovered Plex servers that did not answer this run or are no longer reachable.
+     */
+    const pruneUnreachablePlexServers = async (currentServerIds: Set<string>): Promise<void> => {
+      const storedKeys = await storage.getKeys(plexServersKeyPrefix)
+      for (const key of storedKeys) {
+        const resourceIdentifier = key.split(':').pop()
+        if (resourceIdentifier && !currentServerIds.has(resourceIdentifier)) {
+          logger.info(`PLEX server '${resourceIdentifier}' is gone or no longer reachable, removing it from storage`)
+          await storage.removeItem(key)
+        }
+      }
+      logger.info(`GDM Discovery finished, ${currentServerIds.size} reachable PLEX server(s) available`)
+    }
 
     discoverySocket.bind(() => {
       discoverySocket.setBroadcast(true)
@@ -60,52 +182,17 @@ async function runGdmDiscovery() {
     discoverySocket.send(messageBuffer, 0, messageBuffer.length, pmsDiscoveryPort, broadcastAddress, (err) => {
       if (err) {
         logger.error('Error sending discovery packet:', err)
-        discoverySocket.close()
-        return
+        closeSocketOnce()
       }
     })
 
-    discoverySocket.on('message', async (msg, rinfo) => {
-      const responseData = msg.toString()
-      if (responseData.includes('HTTP/1.0 200 OK')) {
-        const plexServer = parseServerResponse(responseData, rinfo.address)
-        if (!plexServer || plexServer.contentType !== 'plex/media-server') {
-          logger.warn('Unexpected GDM Discovery response:', responseData)
-          return
-        }
-        logger.info(
-          `Discovered PLEX server '${plexServer.name}' at ${plexServer.localAddress}:${plexServer.port} (host: ${plexServer.host})`
-        )
-
-        // Verify connectivity to the Plex server
-        const verifyUrl = `${plexServer.protocol}://${plexServer.localAddress}:${plexServer.port}/identity`
-        // Plexamp will provide the secure address (192-168-1-5.ztea2cf712e03f2b540150acfe3a4b.plex.direct) along the squeeze player requests,
-        // so we need to ensure it is reachable as well to prevent connectivity issues later on when the secure address is used for streaming or talking to the Plex server API.
-        const verifySecureUrl = `${plexServer.secureProtocol}://${plexServer.secureAddress}:${plexServer.port}/identity`
-        try {
-          await verifyPlexServerConnectivity(verifyUrl)
-          await verifyPlexServerConnectivity(verifySecureUrl)
-          await storage.setItem(`plexServer`, plexServer)
-        } catch (error) {
-          // Skip storing this server since it does not appear to be reachable, but log the error for debugging purposes
-          logger.error(error)
-        } finally {
-          discoverySocket.close()
-        }
+    discoveryTimeout = setTimeout(() => {
+      if (respondedServerIds.size === 0) {
+        logger.info(`GDM Discovery no response received within ${discoveryWindowMs / 1000}s, trying again later ..`)
       }
-    })
-
-    discoverySocket.on('error', (err) => {
-      logger.error('Error on GDM Discovery:', err)
-      discoverySocket.close()
-    })
-    setTimeout(() => {
-      logger.info('GDM Discovery no response received within 30s, trying again later ..')
-      discoverySocket.close()
-    }, 300000)
-  } catch (error) {
-    logger.error('Error during GDM Discovery:', error)
-  }
+      closeSocketOnce()
+    }, discoveryWindowMs)
+  })
 }
 
 export async function verifyPlexServerConnectivity(verifyUrl: string): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes #101 — the hub crashed with `ERR_SOCKET_DGRAM_NOT_RUNNING` whenever more than one Plex Media Server answered the GDM discovery broadcast, because the discovery socket was closed in the message handler's `finally` block, which ran once per response. A second server's response tried to close an already-closed socket.

Rather than pick one server and silently ignore the rest, `gdmDiscovery` now supports multiple PMS:

- All socket closes go through a single idempotent `closeSocketOnce()`, shared by the timeout, the `error` handler, and the `send` error callback. It also tolerates a `close()` that throws and still finishes the run cleanly, so the task can't hang.
- The socket stays open for the full discovery window (10s, was previously configured for 300s while logging "within 30s") instead of closing at the first response, so every PMS on the network gets collected, not just the first one.
- Duplicate responses from the same server are ignored, and each reachable server is stored under `plexServers/{resourceIdentifier}` — mirroring the existing `servers/{serverId}` pattern used for LMS — instead of a single `plexServer` key that the last responder silently overwrote.
- Servers that stop answering or become unreachable are pruned from storage each run.
- `runGdmDiscovery()` now resolves only once the window has closed and all connectivity checks have finished, so the scheduled task actually awaits its own work.

**Playback is unaffected either way.** The `plexServer` storage key was already write-only — nothing read it back. Every `createPlayQueue`/`playMedia` request carries its own server info from the Plex client, stored per-player in the play queue and reused for streaming/timelines. So multiple PMS already worked for playback; this only fixes the crash and turns the diagnostic discovery list into something actually correct for multiple servers.

`AGENTS.md` is updated with the new storage key, a corrected discovery-loop diagram, and a short "Multiple Plex Media Servers" section explaining why no server is ever "chosen".

## Test plan

- [x] Added `runGdmDiscovery` tests using a fake `dgram` socket: multiple servers stored, socket closed exactly once with multiple responders, no double-close after an `error` event, duplicate responses ignored, stale entries pruned, unreachable servers skipped and pruned.
- [x] `yarn test` — 137 passed, 34 files.
- [x] `yarn lint` — clean (two pre-existing unrelated Vue warnings).
- [x] `yarn build` — succeeds with TypeScript strict typecheck on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)